### PR TITLE
Store touch screen calibration settings to flash memory and load it on boot...

### DIFF
--- a/platform/spark/modules/EEPROM/eGuiSettings.h
+++ b/platform/spark/modules/EEPROM/eGuiSettings.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 BrewPi/Elco Jacobs/Matthew McGowan.
+ *
+ * This file is part of BrewPi.
+ * 
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EGUISETTINGS_H
+#define	EGUISETTINGS_H
+
+extern "C" {
+#include "d4d.h"
+}
+
+#include "flashee-eeprom.h"
+#include "SparkEepromRegions.h"
+
+
+// Reserve 32 bytes for touch calibration settings to have room for growth
+union calibrationSettingsArea {
+    D4D_TOUCHSCREEN_CALIB touchCalib;
+    unsigned char reserved[32];
+};
+
+// relative addresses in flashee block
+#define TOUCH_CALIB_ADDRESS 0
+#define NEXT_ADDRESS (TOUCH_CALIB_ADDRESS + sizeof(calibrationSettingsArea)
+
+class eGuiSettingsClass {
+    Flashee::FlashDevice* flash;
+
+public:
+
+    eGuiSettingsClass() {
+        flash = Flashee::Devices::createAddressErase(4096 * EEPROM_EGUI_SETTINGS_START_BLOCK, 4096 * EEPROM_EGUI_SETTINGS_END_BLOCK);
+    };
+
+    /**
+     * Checks whether valid touch screen calibration data is stored in flash memory
+     * and loads it in eGUI
+     * @return true if valid data was found, false if not and calibration is needed
+     */
+    bool loadTouchCalib() {
+        D4D_TOUCHSCREEN_CALIB calib;
+        flash->read(&calib, TOUCH_CALIB_ADDRESS, sizeof (D4D_TOUCHSCREEN_CALIB));
+        if (calib.ScreenCalibrated != 1) {
+            return false;
+        }
+        D4D_TCH_SetCalibration(calib);
+        return true;
+    };
+
+    /**
+     * Stores current touch screen calibration data from eGUI to flash memory
+     */
+    void storeTouchCalib() {
+        D4D_TOUCHSCREEN_CALIB calib = D4D_TCH_GetCalibration();
+        flash->write(&calib, TOUCH_CALIB_ADDRESS, sizeof (D4D_TOUCHSCREEN_CALIB));
+    };
+};
+
+extern eGuiSettingsClass eGuiSettings;
+
+#endif	/* EGUISETTINGS_H */
+

--- a/platform/spark/modules/eGUI_screens/UI.cpp
+++ b/platform/spark/modules/eGUI_screens/UI.cpp
@@ -1,12 +1,34 @@
+/*
+ * Copyright 2015 BrewPi/Elco Jacobs/Matthew McGowan.
+ *
+ * This file is part of BrewPi.
+ * 
+ * BrewPi is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * BrewPi is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "Brewpi.h"
 #include "UI.h"
 #include "Buzzer.h"
+#include "eGuiSettings.h"
 
 extern "C" {
 #include "d4d.h"
 }
 
 #include "brewpi_boot_screen.h"
+
+eGuiSettingsClass eGuiSettings;
 
 uint8_t UI::init() {
     if (!D4D_Init(&screen_boot))
@@ -18,13 +40,21 @@ uint8_t UI::init() {
 	buzzer.init();
 	buzzer.beep(2, 100);
     #endif
+        
     return 0;
 }
 
 uint32_t UI::showStartupPage()
-{
-    D4D_CalibrateTouchScreen();
-    D4D_Poll();    
+{   
+    // Check if touch screen has been calibrated
+    if(!eGuiSettings.loadTouchCalib()){
+        // could not load valid settings from flash memory
+        D4D_CalibrateTouchScreen();
+        eGuiSettings.storeTouchCalib();
+    }
+    // Poll to show boot screen
+    D4D_Poll();
+    
     return 0;
 }
         
@@ -36,7 +66,6 @@ void UI::showControllerPage()
     // for now we in fact show what will be the startup page. 
     
 }
-
 
 void UI::update() 
 {


### PR DESCRIPTION
This implements touch screen calibration data storage to flash memory.

On boot, it loads calibration data from flash.
If valid data has been found, it loads it and skips the calibration routine. If not, it runs the calibration routine and stores the data afterwards.

I reserved 32 bytes (9 used) and already added a location for next eGui settings data object. Check if you think whether the format makes sense.

Possible improvements:
* Also check the calibration data itself to see whether it is within expected ranges, instead of just the flag

Test (with GDB debugging):
* Flash to Spark Core
* Set breakpoint here on eGuiSettings.h line 61 ` if (calib.ScreenCalibrated != 1) `
* In the variables tab in Netbeans, inspect `calib`
* Calibrate the touch screen
* Reboot
* Verify that calib now contains valid data loaded from memory and that the calibration routine is skipped