### PR TITLE
Feature/erase eeprom

### DIFF
--- a/app/controller/Brewpi.cpp
+++ b/app/controller/Brewpi.cpp
@@ -63,8 +63,10 @@ UI ui;
 
 void setup()
 {
-	ui.init();
-	piLink.init();
+    platform_init();
+    eepromManager.init();
+    ui.init();
+    piLink.init();
 
     uint32_t start = millis();
     uint32_t delay = ui.showStartupPage();

--- a/app/controller/Brewpi.cpp
+++ b/app/controller/Brewpi.cpp
@@ -63,7 +63,7 @@ UI ui;
 
 void setup()
 {
-    platform_init();
+    bool resetEeprom = platform_init();
     eepromManager.init();
     ui.init();
     piLink.init();
@@ -74,20 +74,22 @@ void setup()
         ui.update();
     }
     
-	logDebug("started");	
-	tempControl.init();
-	settingsManager.loadSettings();
+    logDebug("started");	
+    tempControl.init();
+    settingsManager.loadSettings();
 	
 #if BREWPI_SIMULATE
-	simulator.step();
-	// initialize the filters with the assigned initial temp value
-	tempControl.beerSensor->init();
-	tempControl.fridgeSensor->init();	
+    simulator.step();
+    // initialize the filters with the assigned initial temp value
+    tempControl.beerSensor->init();
+    tempControl.fridgeSensor->init();	
 #endif	
-
+    if (resetEeprom)
+        eepromManager.initializeEeprom();
+        
     ui.showControllerPage();
-    			
-	logDebug("init complete");
+    
+    logDebug("init complete");
 }
 
 void brewpiLoop(void)

--- a/app/controller/Brewpi.h
+++ b/app/controller/Brewpi.h
@@ -39,7 +39,7 @@
 #define BREWPI_BOARD_PHOTON 'y'
 #define BREWPI_BOARD_UNKNOWN '?'
 
-void platform_init();
+bool platform_init();
 
 /*
  * Defines global config for the brewpi project. This file is included in every file in the project to ensure conditional

--- a/app/controller/Brewpi.h
+++ b/app/controller/Brewpi.h
@@ -39,6 +39,8 @@
 #define BREWPI_BOARD_PHOTON 'y'
 #define BREWPI_BOARD_UNKNOWN '?'
 
+void platform_init();
+
 /*
  * Defines global config for the brewpi project. This file is included in every file in the project to ensure conditional
  * compilation directives are recognized.

--- a/app/controller/EepromManager.cpp
+++ b/app/controller/EepromManager.cpp
@@ -33,19 +33,18 @@ EepromAccess eepromAccess;
 
 EepromManager::EepromManager()
 {
-	eepromSizeCheck();
+    eepromSizeCheck();
 }
 
 void EepromManager::init() 
-{
-    eepromAccess.init();
+{    
 }
 
 
 bool EepromManager::hasSettings()
 {
-	uint8_t version = eepromAccess.readByte(pointerOffset(version));	
-	return (version==EEPROM_FORMAT_VERSION);
+    uint8_t version = eepromAccess.readByte(pointerOffset(version));	
+    return (version==EEPROM_FORMAT_VERSION);
 }
 
 void EepromManager::zapEeprom()
@@ -57,34 +56,34 @@ void EepromManager::zapEeprom()
 
 void EepromManager::initializeEeprom()
 {
-	// clear all eeprom
-	for (uint16_t offset=0; offset<EepromFormat::MAX_EEPROM_SIZE; offset++)
-		eepromAccess.writeByte(offset, 0);	
+    // clear all eeprom
+    for (uint16_t offset=0; offset<EepromFormat::MAX_EEPROM_SIZE; offset++)
+            eepromAccess.writeByte(offset, 0);	
 
-	deviceManager.setupUnconfiguredDevices();
+    deviceManager.setupUnconfiguredDevices();
 
-	// fetch the default values
-	tempControl.loadDefaultConstants();
-	tempControl.loadDefaultSettings();	
-	
-	// write the default constants 
-	for (uint8_t c=0; c<EepromFormat::MAX_CHAMBERS; c++) {
-		eptr_t pv = pointerOffset(chambers)+(c*sizeof(ChamberBlock)) ;
-		tempControl.storeConstants(pv+offsetof(ChamberBlock, chamberSettings.cc));
-		pv += offsetof(ChamberBlock, beer)+offsetof(BeerBlock, cs);
-		for (uint8_t b=0; b<ChamberBlock::MAX_BEERS; b++) {
-//			logDeveloper(PSTR("EepromManager - saving settings for beer %d at %d"), b, (uint16_t)pv);
-			tempControl.storeSettings(pv);	
-			pv += sizeof(BeerBlock);		// advance to next beer
-		}
-	}
+    // fetch the default values
+    tempControl.loadDefaultConstants();
+    tempControl.loadDefaultSettings();	
 
-	// set the version flag - so that storeDevice will work
-	eepromAccess.writeByte(0, EEPROM_FORMAT_VERSION);
-		
-	saveDefaultDevices();
-	// set state to startup
-	tempControl.init();
+    // write the default constants 
+    for (uint8_t c=0; c<EepromFormat::MAX_CHAMBERS; c++) {
+        eptr_t pv = pointerOffset(chambers)+(c*sizeof(ChamberBlock)) ;
+        tempControl.storeConstants(pv+offsetof(ChamberBlock, chamberSettings.cc));
+        pv += offsetof(ChamberBlock, beer)+offsetof(BeerBlock, cs);
+        for (uint8_t b=0; b<ChamberBlock::MAX_BEERS; b++) {
+//          logDeveloper(PSTR("EepromManager - saving settings for beer %d at %d"), b, (uint16_t)pv);
+            tempControl.storeSettings(pv);	
+            pv += sizeof(BeerBlock);		// advance to next beer
+        }
+    }
+
+    // set the version flag - so that storeDevice will work
+    eepromAccess.writeByte(0, EEPROM_FORMAT_VERSION);
+
+    saveDefaultDevices();
+    // set state to startup
+    tempControl.init();
 }
 
 uint8_t EepromManager::saveDefaultDevices() 

--- a/app/controller/EepromManager.cpp
+++ b/app/controller/EepromManager.cpp
@@ -36,6 +36,11 @@ EepromManager::EepromManager()
 	eepromSizeCheck();
 }
 
+void EepromManager::init() 
+{
+    eepromAccess.init();
+}
+
 
 bool EepromManager::hasSettings()
 {

--- a/app/controller/EepromManager.h
+++ b/app/controller/EepromManager.h
@@ -36,6 +36,11 @@ class EepromManager {
 public:		
 		
 	EepromManager();
+        
+        /**
+         * Initialize the eeprom manager.
+         */
+        static void init();
 	
 	/**
 	 * Write -1 to the entire eeprom, emulating the reset performed by avrdude.

--- a/platform/avr/ArduinoEepromAccess.h
+++ b/platform/avr/ArduinoEepromAccess.h
@@ -23,17 +23,21 @@
 class ArduinoEepromAccess
 {
 public:
-	static uint8_t readByte(eptr_t offset) {
-		return eeprom_read_byte((uint8_t*)offset);
-	}
-	static void writeByte(eptr_t offset, uint8_t value) {
-		eeprom_update_byte((uint8_t*)offset, value);
-	}
-	
-	static void readBlock(void* target, eptr_t offset, uint16_t size) {
-		eeprom_read_block(target, (uint8_t*)offset, size);
-	}
-	static void writeBlock(eptr_t target, const void* source, uint16_t size) {
-		eeprom_update_block(source, (void*)target, size);
-	}	
+    static void init() {
+        
+    }
+    
+    static uint8_t readByte(eptr_t offset) {
+            return eeprom_read_byte((uint8_t*)offset);
+    }
+    static void writeByte(eptr_t offset, uint8_t value) {
+            eeprom_update_byte((uint8_t*)offset, value);
+    }
+
+    static void readBlock(void* target, eptr_t offset, uint16_t size) {
+            eeprom_read_block(target, (uint8_t*)offset, size);
+    }
+    static void writeBlock(eptr_t target, const void* source, uint16_t size) {
+            eeprom_update_block(source, (void*)target, size);
+    }	
 };

--- a/platform/avr/Platform.cpp
+++ b/platform/avr/Platform.cpp
@@ -97,7 +97,8 @@ int8_t DeviceManager::enumOneWirePins(uint8_t offset)
     return -1;								
 }
 
-void platform_init()
+bool platform_init()
 {
-    // nothing to do here yet
+    eepromAccess.init();
+    return false;
 }

--- a/platform/avr/Platform.cpp
+++ b/platform/avr/Platform.cpp
@@ -96,3 +96,8 @@ int8_t DeviceManager::enumOneWirePins(uint8_t offset)
 #endif
     return -1;								
 }
+
+void platform_init()
+{
+    // nothing to do here yet
+}

--- a/platform/spark/modules/EEPROM/EepromAccessImpl.h
+++ b/platform/spark/modules/EEPROM/EepromAccessImpl.h
@@ -7,7 +7,7 @@ class SparkEepromAccess
 {
     Flashee::FlashDevice* flash;
 public:
-    SparkEepromAccess() 
+    void init() 
     {
         flash = Flashee::Devices::createAddressErase(4096*EEPROM_CONTROLLER_START_BLOCK, 4096*EEPROM_CONTROLLER_END_BLOCK);
     }

--- a/platform/spark/modules/EEPROM/eGuiSettings.h
+++ b/platform/spark/modules/EEPROM/eGuiSettings.h
@@ -43,7 +43,7 @@ class eGuiSettingsClass {
 
 public:
 
-    eGuiSettingsClass() {
+    void init() {
         flash = Flashee::Devices::createAddressErase(4096 * EEPROM_EGUI_SETTINGS_START_BLOCK, 4096 * EEPROM_EGUI_SETTINGS_END_BLOCK);
     };
 

--- a/platform/spark/modules/Platform.cpp
+++ b/platform/spark/modules/Platform.cpp
@@ -3,12 +3,13 @@
 #include "DeviceManager.h"
 #include "Pins.h"
 #include "ymodem/ymodem.h"
+#include "flashee-eeprom.h"
 
 SYSTEM_MODE(SEMI_AUTOMATIC)
 
 void handleReset() 
 { 
-	System.reset();
+    System.reset();
 }
 
 void flashFirmware()
@@ -23,10 +24,10 @@ OneWire primaryOneWireBus(oneWirePin);
 
 OneWire* DeviceManager::oneWireBus(uint8_t pin) {
 #if !BREWPI_SIMULATE
-	if (pin==oneWirePin)
-		return &primaryOneWireBus;
+    if (pin==oneWirePin)
+            return &primaryOneWireBus;
 #endif
-	return NULL;
+    return NULL;
 }
 
 
@@ -53,4 +54,26 @@ int8_t DeviceManager::enumOneWirePins(uint8_t offset)
     if (offset==0)
         return oneWirePin;
     return -1;								
+}
+
+
+#define EEPROM_MAGIC1 (0xD0)
+#define EEPROM_MAGIC2 (0x7E)
+
+void eraseExternalFlash()
+{
+#if PLATFORM_ID==PLATFORM_SPARK_CORE
+    Flashee::Devices::userFlash().eraseAll();
+#endif    
+}
+
+void platform_init()
+{        
+    if (EEPROM.read(0)!=EEPROM_MAGIC1 || EEPROM.read(1)!=EEPROM_MAGIC2) {
+        
+        eraseExternalFlash();
+        
+        EEPROM.write(0, EEPROM_MAGIC1);
+        EEPROM.write(1, EEPROM_MAGIC2);
+    }
 }

--- a/platform/spark/modules/Platform.cpp
+++ b/platform/spark/modules/Platform.cpp
@@ -4,6 +4,7 @@
 #include "Pins.h"
 #include "ymodem/ymodem.h"
 #include "flashee-eeprom.h"
+#include "EepromManager.h"
 
 SYSTEM_MODE(SEMI_AUTOMATIC)
 
@@ -64,6 +65,7 @@ void eraseExternalFlash()
 {
 #if PLATFORM_ID==PLATFORM_SPARK_CORE
     Flashee::Devices::userFlash().eraseAll();
+    eepromManager.initializeEeprom();
 #endif    
 }
 

--- a/platform/spark/modules/Platform.cpp
+++ b/platform/spark/modules/Platform.cpp
@@ -59,23 +59,25 @@ int8_t DeviceManager::enumOneWirePins(uint8_t offset)
 
 
 #define EEPROM_MAGIC1 (0xD0)
-#define EEPROM_MAGIC2 (0x7E)
+#define EEPROM_MAGIC2 (0x9E)
 
 void eraseExternalFlash()
 {
 #if PLATFORM_ID==PLATFORM_SPARK_CORE
-    Flashee::Devices::userFlash().eraseAll();
-    eepromManager.initializeEeprom();
+    Flashee::Devices::userFlash().eraseAll();    
 #endif    
 }
 
-void platform_init()
-{        
-    if (EEPROM.read(0)!=EEPROM_MAGIC1 || EEPROM.read(1)!=EEPROM_MAGIC2) {
+bool platform_init()
+{            
+    bool initialize = (EEPROM.read(0)!=EEPROM_MAGIC1 || EEPROM.read(1)!=EEPROM_MAGIC2);
+    if (initialize) {
         
         eraseExternalFlash();
         
         EEPROM.write(0, EEPROM_MAGIC1);
         EEPROM.write(1, EEPROM_MAGIC2);
     }
+    eepromAccess.init();
+    return initialize;
 }

--- a/platform/spark/modules/eGUI_screens/UI.cpp
+++ b/platform/spark/modules/eGUI_screens/UI.cpp
@@ -37,6 +37,8 @@ extern "C" {
 eGuiSettingsClass eGuiSettings;
 
 uint8_t UI::init() {
+    eGuiSettings.init();
+    
     if (!D4D_Init(NULL))
         return 1;
     


### PR DESCRIPTION
This requires the latest changes from the spark firmware repo - inlining EEPROM functions causes failure. (strangely.)

To test:
- power on the device
- it will run screen calibration and initialise all eeprom settings
- restart the device
- screen calibration will not be run (and startup will be a little quicker)

