### PR TITLE
Fixes for OneWire actuator and sensor (DS2413)

### DIFF
--- a/platform/wiring/DS2413.h
+++ b/platform/wiring/DS2413.h
@@ -84,7 +84,7 @@ public:
 	}
 	
 	// assumes pio is either 0 or 1, which translates to masks 0x1 and 0x2
-	uint8_t pioMask(pio_t pio) { return pio++; }
+	uint8_t pioMask(pio_t pio) { return ++pio; }
 
 	/*
 	 * Reads the output state of a given channel, defaulting to a given value on error.

--- a/platform/wiring/OneWireActuator.h
+++ b/platform/wiring/OneWireActuator.h
@@ -55,8 +55,8 @@ public:
 	
 #if DS2413_SUPPORT_SENSE
 	bool sense() {
-		device.channelWrite(pio, 0);
-		return device.channelSense(pio, invert);	// on device failure, default is high for invert, low for regular.
+		device.channelWrite(pio, 1);	//Note that for a read to make sense the channel must be off (value written is 1).
+		return (device.channelSense(pio, invert)^invert);	// on device failure, default is high for invert, low for regular.
 	}
 #endif
 			


### PR DESCRIPTION
pioMask() function was not returning correct value as was incrementing
after returning. Changed to increment before returning.

OneWireActuator sense() function was not applying invert option
correctly. This has been tested but there is a current issue with the
multiple inheritance of the "OneWireActuator" class for both "Actuator"
and SwitchSensor". If the order of these 2 are switched the sensor
functionality via DS2413 works correctly but actuators via DS2413 no
longer work. I have not been able to resolve this issue so for now door
sensor does not work via DS2413.