### PR TITLE
Use smart pointers instead of raw pointers

### DIFF
--- a/app/controller/Control.cpp
+++ b/app/controller/Control.cpp
@@ -45,21 +45,21 @@ Control::Control()
 
     mutex = new ActuatorMutexGroup();
 
-    heater1Mutex = new ActuatorMutexDriver(defaultActuator(), mutex);
-    heater1 = new ActuatorPwm(heater1Mutex, 4); // period 4s
+    heater1Mutex = std::make_shared<ActuatorMutexDriver>(defaultActuator(), mutex);
+    heater1 = std::make_shared<ActuatorPwm>(heater1Mutex, 4); // period 4s
 
-    heater2Mutex = new ActuatorMutexDriver(defaultActuator(), mutex);
-    heater2 = new ActuatorPwm(heater2Mutex, 4); // period 4s
+    heater2Mutex = std::make_shared<ActuatorMutexDriver>(defaultActuator(), mutex);
+    heater2 = std::make_shared<ActuatorPwm>(heater2Mutex, 4); // period 4s
 
-    coolerTimeLimited = new ActuatorTimeLimited(defaultActuator(), 120, 180); // 2 min minOn time, 3 min minOff
-    coolerMutex = new ActuatorMutexDriver(coolerTimeLimited, mutex);
-    cooler = new ActuatorPwm(coolerMutex, 1200); // period 20 min
+    coolerTimeLimited = std::make_shared<ActuatorTimeLimited>(defaultActuator(), 120, 180); // 2 min minOn time, 3 min minOff
+    coolerMutex = std::make_shared<ActuatorMutexDriver>(coolerTimeLimited, mutex);
+    cooler = std::make_shared<ActuatorPwm>(coolerMutex, 1200); // period 20 min
 
     beer1Set = new SetPointSimple();
     beer2Set = new SetPointSimple();
     fridgeSet = new SetPointSimple();
 
-    fridgeSetPointActuator = new ActuatorSetPoint(fridgeSet, fridgeSensor, beer1Set);
+    fridgeSetPointActuator = std::make_shared<ActuatorSetPoint>(fridgeSet, fridgeSensor, beer1Set);
     fridgeSetPointActuator->setMin(-10.0);
     fridgeSetPointActuator->setMax(10.0);
 
@@ -108,18 +108,6 @@ Control::~Control(){
     // global control object is static and never destroyed.
     // omit proper destructor to save space.
 #else
-    delete heater1Mutex;
-    delete heater1;
-
-    delete heater2Mutex;
-    delete heater2;
-
-    delete coolerTimeLimited;
-    delete coolerMutex;
-    delete cooler;
-
-    delete fridgeSetPointActuator;
-
     delete beer1Set;
     delete beer2Set;
     delete fridgeSet;

--- a/app/controller/Control.h
+++ b/app/controller/Control.h
@@ -50,7 +50,7 @@ public:
     std::vector<SetPointNamed*> setpoints;
     std::vector<TempSensor*> sensors;
     std::vector<Pid*>        pids;
-    std::vector<Actuator*>   actuators;
+    std::vector<std::shared_ptr<Actuator>> actuators;
 
     // static setup below, we should support generating this dynamically later
 protected:
@@ -58,17 +58,17 @@ protected:
     TempSensor * beer1Sensor;
     TempSensor * beer2Sensor;
 
-    ActuatorTimeLimited * coolerTimeLimited;
-    ActuatorMutexDriver * coolerMutex;
-    ActuatorPwm * cooler;
+    std::shared_ptr<ActuatorTimeLimited> coolerTimeLimited;
+    std::shared_ptr<ActuatorMutexDriver> coolerMutex;
+    std::shared_ptr<ActuatorPwm> cooler;
 
-    ActuatorMutexDriver * heater1Mutex;
-    ActuatorPwm * heater1;
+    std::shared_ptr<ActuatorMutexDriver> heater1Mutex;
+    std::shared_ptr<ActuatorPwm> heater1;
 
-    ActuatorMutexDriver * heater2Mutex;
-    ActuatorPwm * heater2;
+    std::shared_ptr<ActuatorMutexDriver> heater2Mutex;
+    std::shared_ptr<ActuatorPwm> heater2;
 
-    ActuatorSetPoint * fridgeSetPointActuator;
+    std::shared_ptr<ActuatorSetPoint> fridgeSetPointActuator;
 
     ActuatorMutexGroup * mutex;
 

--- a/app/controller/defaultDevices.cpp
+++ b/app/controller/defaultDevices.cpp
@@ -19,19 +19,20 @@
  */
 
 #include "defaultDevices.h"
+#include <memory>
 
 ValueSensor<bool> * defaultSensor(){
     static ValueSensor<bool> * s = new ValueSensor<bool>(false);
     return s;
 }
 
-ActuatorNop * defaultActuator(){
-    static ActuatorNop * a = new ActuatorNop;
+std::shared_ptr<ActuatorDigital> defaultActuator(){
+    static std::shared_ptr<ActuatorDigital> a = std::make_shared<ActuatorNop>();
     return a;
 }
 
-ActuatorInvalid * defaultLinearActuator(){ // always returns invalid and does nothing
-    static ActuatorInvalid * a = new ActuatorInvalid;
+std::shared_ptr<ActuatorRange> defaultLinearActuator(){ // always returns invalid and does nothing
+    static std::shared_ptr<ActuatorRange> a = std::make_shared<ActuatorInvalid>();
     return a;
 }
 

--- a/app/controller/defaultDevices.h
+++ b/app/controller/defaultDevices.h
@@ -27,8 +27,8 @@
 #include "Sensor.h"
 
 ValueSensor<bool> * defaultSensor();
-ActuatorNop * defaultActuator();
-ActuatorInvalid * defaultLinearActuator(); // always returns invalid and does nothing
+std::shared_ptr<ActuatorDigital> defaultActuator();
+std::shared_ptr<ActuatorRange> defaultLinearActuator();
 TempSensorDisconnected * defaultTempSensorBasic();
 SetPointConstant * defaultSetPoint();
 

--- a/app/controller/esj/json_adapter.h
+++ b/app/controller/esj/json_adapter.h
@@ -67,6 +67,7 @@
 // requires lexer for token types.
 #include "json_lexer.h"
 #include "temperatureFormats.h"
+#include <memory>
 
 namespace JSON
 {
@@ -383,6 +384,24 @@ inline void stream(Adapter& adapter,T* arg)
     arg->serialize(adapter);
 }
 
+
+//-----------------------------------------------------------------------------
+// shared_ptr<T>.
+template <typename T>
+inline void stream(Adapter& adapter, std::shared_ptr<T> arg)
+{
+    //
+    arg.get()->serialize(adapter);
+}
+
+//-----------------------------------------------------------------------------
+// shared_ptr<T>.
+template <typename T>
+inline void stream(Adapter& adapter,const std::string& key, std::shared_ptr<T> & value,bool more)
+{
+    stream(adapter,key, value.get(), more);
+}
+
 //-----------------------------------------------------------------------------
 // serialize a single instance of T. 
 // Highlights an asymmetry in JSON (or more likely Javascript ...)
@@ -392,6 +411,7 @@ inline void stream(Adapter& adapter,const std::string& key,T& value,bool more)
     // use class pointer function below
     stream(adapter,key, &value, more);
 }
+
 
 //-----------------------------------------------------------------------------
 // serialize a single instance of T, where T is a class pointer.

--- a/boost_test/ActuatorMutexTest.cpp
+++ b/boost_test/ActuatorMutexTest.cpp
@@ -35,12 +35,12 @@
 BOOST_AUTO_TEST_SUITE(ActuatorMutexTest)
 
 BOOST_AUTO_TEST_CASE(two_actuators_belonging_to_the_same_group_cannot_be_active_at_once) {
-    ActuatorDigital * act1 = new ActuatorBool();
-    ActuatorDigital * act2 = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> act1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> act2 = std::make_shared<ActuatorBool>();
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
 
-    ActuatorMutexDriver * actm1 = new ActuatorMutexDriver(act1);
-    ActuatorMutexDriver * actm2 = new ActuatorMutexDriver(act2);
+    std::shared_ptr<ActuatorMutexDriver> actm1 = std::make_shared<ActuatorMutexDriver>(act1);
+    std::shared_ptr<ActuatorMutexDriver> actm2 = std::make_shared<ActuatorMutexDriver>(act2);
     actm1->setMutex(mutex);
     actm2->setMutex(mutex);
 
@@ -62,12 +62,12 @@ BOOST_AUTO_TEST_CASE(two_actuators_belonging_to_the_same_group_cannot_be_active_
 
 
 BOOST_AUTO_TEST_CASE(dead_time_between_actuators_is_honored) {
-    ActuatorDigital * act1 = new ActuatorBool();
-    ActuatorDigital * act2 = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> act1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> act2 = std::make_shared<ActuatorBool>();
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
 
-    ActuatorMutexDriver * actm1 = new ActuatorMutexDriver(act1);
-    ActuatorMutexDriver * actm2 = new ActuatorMutexDriver(act2);
+    std::shared_ptr<ActuatorMutexDriver> actm1 = std::make_shared<ActuatorMutexDriver>(act1);
+    std::shared_ptr<ActuatorMutexDriver> actm2 = std::make_shared<ActuatorMutexDriver>(act2);
     actm1->setMutex(mutex);
     actm2->setMutex(mutex);
 
@@ -105,12 +105,12 @@ BOOST_AUTO_TEST_CASE(dead_time_between_actuators_is_honored) {
 
 
 BOOST_AUTO_TEST_CASE(dead_time_does_not_block_same_actuator_from_going_active_again) {
-    ActuatorDigital * act1 = new ActuatorBool();
-    ActuatorDigital * act2 = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> act1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> act2 = std::make_shared<ActuatorBool>();
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
 
-    ActuatorMutexDriver * actm1 = new ActuatorMutexDriver(act1);
-    ActuatorMutexDriver * actm2 = new ActuatorMutexDriver(act2);
+    std::shared_ptr<ActuatorMutexDriver> actm1 = std::make_shared<ActuatorMutexDriver>(act1);
+    std::shared_ptr<ActuatorMutexDriver> actm2 = std::make_shared<ActuatorMutexDriver>(act2);
     actm1->setMutex(mutex);
     actm2->setMutex(mutex);
 
@@ -131,17 +131,17 @@ BOOST_AUTO_TEST_CASE(dead_time_does_not_block_same_actuator_from_going_active_ag
 
 
 BOOST_AUTO_TEST_CASE(mutex_works_with_time_limited_actuator) {
-    ActuatorDigital * act1 = new ActuatorBool();
-    ActuatorTimeLimited * act1tl = new ActuatorTimeLimited(act1, 10, 20);
-    ActuatorDigital * act2 = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> act1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorTimeLimited> act1tl = std::make_shared<ActuatorTimeLimited>(act1, 10, 20);
+    std::shared_ptr<ActuatorDigital> act2 = std::make_shared<ActuatorBool>();
 
     delay(20000); // let initial minimum off time pass
 
 
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
 
-    ActuatorMutexDriver * actm1 = new ActuatorMutexDriver(act1tl);
-    ActuatorMutexDriver * actm2 = new ActuatorMutexDriver(act2);
+    std::shared_ptr<ActuatorMutexDriver> actm1 = std::make_shared<ActuatorMutexDriver>(act1tl);
+    std::shared_ptr<ActuatorMutexDriver> actm2 = std::make_shared<ActuatorMutexDriver>(act2);
     actm1->setMutex(mutex);
     actm2->setMutex(mutex);
 
@@ -166,17 +166,17 @@ BOOST_AUTO_TEST_CASE(mutex_works_with_time_limited_actuator) {
 BOOST_AUTO_TEST_CASE(when_there_have_been_no_requests_for_a_while_dead_time_is_still_honored_on_new_request) {
     // this test was introduced to make sure lastActiveTime is not only updated on requests
 
-    ActuatorDigital * act1 = new ActuatorBool();
-    ActuatorTimeLimited * act1tl = new ActuatorTimeLimited(act1, 10, 20);
-    ActuatorDigital * act2 = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> act1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorTimeLimited> act1tl = std::make_shared<ActuatorTimeLimited>(act1, 10, 20);
+    std::shared_ptr<ActuatorDigital> act2 = std::make_shared<ActuatorBool>();
 
     delay(20000); // let initial minimum off time pass
 
 
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
 
-    ActuatorMutexDriver * actm1 = new ActuatorMutexDriver(act1tl);
-    ActuatorMutexDriver * actm2 = new ActuatorMutexDriver(act2);
+    std::shared_ptr<ActuatorMutexDriver> actm1 = std::make_shared<ActuatorMutexDriver>(act1tl);
+    std::shared_ptr<ActuatorMutexDriver> actm2 = std::make_shared<ActuatorMutexDriver>(act2);
     actm1->setMutex(mutex);
     actm2->setMutex(mutex);
     mutex->setDeadTime(10000); // 10 seconds dead time

--- a/boost_test/ActuatorPwmTest.cpp
+++ b/boost_test/ActuatorPwmTest.cpp
@@ -90,8 +90,8 @@ double randomIntervalTest(ActuatorPwm* act, ActuatorDigital * target, temp_t dut
 BOOST_AUTO_TEST_SUITE(ActuatorPWM)
 
 BOOST_AUTO_TEST_CASE( Test_ActuatorPWM_with_ValueActuator_as_driver) {
-    ActuatorDigital * target = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(target,4);
+    std::shared_ptr<ActuatorDigital> target = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(target,4);
 
     BOOST_CHECK(act->getValue() == temp_t(0.0)); // PWM value is initialized to 0
 
@@ -112,8 +112,8 @@ BOOST_AUTO_TEST_CASE( Test_ActuatorPWM_with_ValueActuator_as_driver) {
 
 BOOST_AUTO_TEST_CASE(on_off_time_matches_duty_cycle_when_updating_every_ms) {
     srand(time(NULL));
-    ActuatorDigital * target = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(target,4);
+    std::shared_ptr<ActuatorDigital> target = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(target,4);
 
     temp_t duty = 50.0;
     act->setValue(duty);
@@ -147,30 +147,30 @@ BOOST_AUTO_TEST_CASE(on_off_time_matches_duty_cycle_when_updating_every_ms) {
 
 BOOST_AUTO_TEST_CASE(average_duty_cycle_is_correct_with_random_update_intervals) {
     srand(time(NULL));
-    ActuatorDigital * target = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(target,4);
+    std::shared_ptr<ActuatorDigital> target = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(target,4);
     // check within 0.5 points accurate
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 50.0, 500), 50.0, 1);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 3.0, 500), 3.0, 16.7);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 1.0, 500), 1.0, 50);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 99.0, 500), 99.0, 0.5);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 50.0, 500), 50.0, 1);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 3.0, 500), 3.0, 16.7);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 1.0, 500), 1.0, 50);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 99.0, 500), 99.0, 0.5);
 }
 
 BOOST_AUTO_TEST_CASE(average_duty_cycle_is_correct_with_long_period) {
     srand(time(NULL));
-    ActuatorDigital * target = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(target,3600);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 50.0, 500), 50.0, 1);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 3.0, 500), 3.0, 16.7);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 1.0, 500), 1.0, 50);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, target, 99.0, 500), 99.0, 0.5);
+    std::shared_ptr<ActuatorDigital> target = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(target,3600);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 50.0, 500), 50.0, 1);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 3.0, 500), 3.0, 16.7);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 1.0, 500), 1.0, 50);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), target.get(), 99.0, 500), 99.0, 0.5);
 }
 
 
 
 BOOST_AUTO_TEST_CASE(output_stays_low_with_value_0) {
-    ActuatorDigital * target = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(target,4);
+    std::shared_ptr<ActuatorDigital> target = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(target,4);
 
     act->setValue(0.0);
     // wait target to go low
@@ -187,9 +187,9 @@ BOOST_AUTO_TEST_CASE(output_stays_low_with_value_0) {
 }
 
 BOOST_AUTO_TEST_CASE(on_big_positive_changes_shortened_cycle_has_correct_value) {
-    ActuatorDigital * vAct = new ActuatorBool();
-    ActuatorDigital * limited = new ActuatorTimeLimited(vAct, 0, 0);
-    ActuatorPwm * act = new ActuatorPwm(limited, 100); // period is 100 seconds
+    std::shared_ptr<ActuatorDigital> vAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> limited = std::make_shared<ActuatorTimeLimited>(vAct, 0, 0);
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(limited, 100); // period is 100 seconds
 
     act->setValue(short(30));
     ticks_millis_t start = ticks.millis();
@@ -230,9 +230,9 @@ BOOST_AUTO_TEST_CASE(on_big_positive_changes_shortened_cycle_has_correct_value) 
 
 
 BOOST_AUTO_TEST_CASE(on_big_negative_changes_go_low_immediately) {
-    ActuatorDigital * vAct = new ActuatorBool();
-    ActuatorDigital * limited = new ActuatorTimeLimited(vAct, 0, 0);
-    ActuatorPwm * act = new ActuatorPwm(limited, 100); // period is 100 seconds
+    std::shared_ptr<ActuatorDigital> vAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> limited = std::make_shared<ActuatorTimeLimited>(vAct, 0, 0);
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(limited, 100); // period is 100 seconds
 
     ticks_millis_t lastLowTimeBeforeChange = ticks.millis();
     act->setValue(60.0);
@@ -273,8 +273,8 @@ BOOST_AUTO_TEST_CASE(on_big_negative_changes_go_low_immediately) {
 
 
 BOOST_AUTO_TEST_CASE(output_stays_high_with_value_100) {
-    ActuatorDigital * target = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(target,4);
+    std::shared_ptr<ActuatorDigital> target = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(target,4);
 
     act->setValue(100.0);
     // wait for target to go high
@@ -294,23 +294,23 @@ BOOST_AUTO_TEST_CASE(ActuatorPWM_with_min_max_time_limited_OnOffActuator_as_driv
     // test with minimum ON of 2 seconds, minimum off of 5 seconds and period 10 seconds
 
     srand(time(NULL));
-    ActuatorDigital * vAct = new ActuatorBool();
-    ActuatorDigital * onOffAct = new ActuatorTimeLimited(vAct, 2, 5);
-    ActuatorPwm * act = new ActuatorPwm(onOffAct, 10);
+    std::shared_ptr<ActuatorDigital> vAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> onOffAct = std::make_shared<ActuatorTimeLimited>(vAct, 2, 5);
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(onOffAct, 10);
 
     // Test that average duty cycle is correct, even with minimum times enforced in the actuator
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, vAct, 50.0, 500), 50.0, 1);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, vAct, 3.0, 500), 3.0, 16.7);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, vAct, 1.0, 500), 1.0, 50);
-    BOOST_CHECK_CLOSE(randomIntervalTest(act, vAct, 99.0, 500), 99.0, 0.5);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), vAct.get(), 50.0, 500), 50.0, 1);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), vAct.get(), 3.0, 500), 3.0, 16.7);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), vAct.get(), 1.0, 500), 1.0, 50);
+    BOOST_CHECK_CLOSE(randomIntervalTest(act.get(), vAct.get(), 99.0, 500), 99.0, 0.5);
 }
 
 
 BOOST_AUTO_TEST_CASE(when_switching_between_zero_and_low_value_average_is_correct){
     // test with minimum ON of 2 seconds, minimum off of 5 seconds and period 5 seconds
-    ActuatorDigital * vAct = new ActuatorBool();
-    ActuatorDigital * onOffAct = new ActuatorTimeLimited(vAct, 20, 50);
-    ActuatorPwm * act = new ActuatorPwm(onOffAct, 100);
+    std::shared_ptr<ActuatorDigital> vAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> onOffAct = std::make_shared<ActuatorTimeLimited>(vAct, 20, 50);
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(onOffAct, 100);
 
     ticks_seconds_t timeHigh = 0;
     ticks_seconds_t timeLow = 0;
@@ -348,8 +348,8 @@ BOOST_AUTO_TEST_CASE(when_switching_between_zero_and_low_value_average_is_correc
 
 
 BOOST_AUTO_TEST_CASE(ramping_PWM_up_faster_than_period_gives_correct_average){
-    ActuatorDigital * vAct = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(vAct, 20);
+    std::shared_ptr<ActuatorDigital> vAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(vAct, 20);
     ticks_seconds_t timeHigh = 0;
     ticks_seconds_t timeLow = 0;
 
@@ -375,8 +375,8 @@ BOOST_AUTO_TEST_CASE(ramping_PWM_up_faster_than_period_gives_correct_average){
 
 
 BOOST_AUTO_TEST_CASE(ramping_PWM_down_faster_than_period_gives_correct_average){
-    ActuatorDigital * vAct = new ActuatorBool();
-    ActuatorPwm * act = new ActuatorPwm(vAct, 20);
+    std::shared_ptr<ActuatorDigital> vAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> act = std::make_shared<ActuatorPwm>(vAct, 20);
     ticks_seconds_t timeHigh = 0;
     ticks_seconds_t timeLow = 0;
 
@@ -401,13 +401,13 @@ BOOST_AUTO_TEST_CASE(ramping_PWM_down_faster_than_period_gives_correct_average){
 }
 
 BOOST_AUTO_TEST_CASE(two_mutex_PWM_actuators_can_overlap){
-    ActuatorDigital * boolAct1 = new ActuatorBool();
-    ActuatorMutexDriver * mutexAct1 = new ActuatorMutexDriver(boolAct1);
-    ActuatorPwm * act1 = new ActuatorPwm(mutexAct1, 10);
+    std::shared_ptr<ActuatorDigital> boolAct1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorMutexDriver> mutexAct1 = std::make_shared<ActuatorMutexDriver>(boolAct1);
+    std::shared_ptr<ActuatorPwm> act1 = std::make_shared<ActuatorPwm>(mutexAct1, 10);
 
-    ActuatorDigital * boolAct2 = new ActuatorBool();
-    ActuatorMutexDriver * mutexAct2 = new ActuatorMutexDriver(boolAct2);
-    ActuatorPwm * act2 = new ActuatorPwm(mutexAct2, 10);
+    std::shared_ptr<ActuatorDigital> boolAct2 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorMutexDriver> mutexAct2 = std::make_shared<ActuatorMutexDriver>(boolAct2);
+    std::shared_ptr<ActuatorPwm> act2 = std::make_shared<ActuatorPwm>(mutexAct2, 10);
 
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
     mutex->setDeadTime(0);
@@ -460,8 +460,8 @@ BOOST_AUTO_TEST_CASE(two_mutex_PWM_actuators_can_overlap){
 }
 
 BOOST_AUTO_TEST_CASE(actual_value_returned_by_ActuatorPwm_readValue_is_correct){
-    ActuatorDigital * boolAct = new ActuatorBool();
-    ActuatorPwm * pwmAct = new ActuatorPwm(boolAct, 20);
+    std::shared_ptr<ActuatorDigital> boolAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> pwmAct = std::make_shared<ActuatorPwm>(boolAct, 20);
 
     ofstream csv("./test_results/" + boost_test_name() + ".csv");
     csv << "1#set value, 1#read value, 2a#pin" << endl;
@@ -493,9 +493,9 @@ BOOST_AUTO_TEST_CASE(actual_value_returned_by_ActuatorPwm_readValue_is_correct){
 
 
 BOOST_AUTO_TEST_CASE(actual_value_returned_by_ActuatorPwm_readValue_is_correct_with_time_limited_actuator){
-    ActuatorDigital * boolAct = new ActuatorBool();
-    ActuatorDigital * timeLimitedAct = new ActuatorTimeLimited(boolAct, 2, 5);
-    ActuatorPwm * pwmAct = new ActuatorPwm(timeLimitedAct, 20);
+    std::shared_ptr<ActuatorDigital> boolAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> timeLimitedAct = std::make_shared<ActuatorTimeLimited>(boolAct, 2, 5);
+    std::shared_ptr<ActuatorPwm> pwmAct = std::make_shared<ActuatorPwm>(timeLimitedAct, 20);
 
     ofstream csv("./test_results/" + boost_test_name() + ".csv");
     csv << "1#set value, 1#read value, 2a#pin" << endl;
@@ -528,8 +528,8 @@ BOOST_AUTO_TEST_CASE(actual_value_returned_by_ActuatorPwm_readValue_is_correct_w
 
 
 BOOST_AUTO_TEST_CASE(slowly_changing_pwm_value_reads_back_as_correct_value){
-    ActuatorDigital * boolAct = new ActuatorBool();
-    ActuatorPwm * pwmAct = new ActuatorPwm(boolAct, 20);
+    std::shared_ptr<ActuatorDigital> boolAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorPwm> pwmAct = std::make_shared<ActuatorPwm>(boolAct, 20);
 
     pwmAct->setValue(0.0);
     ticks_millis_t start = ticks.millis();
@@ -561,9 +561,9 @@ BOOST_AUTO_TEST_CASE(slowly_changing_pwm_value_reads_back_as_correct_value){
 
 
 BOOST_AUTO_TEST_CASE(fluctuating_pwm_value_gives_correct_average_with_time_limited_actuator){
-    ActuatorDigital * boolAct = new ActuatorBool();
-    ActuatorDigital * timeLimitedAct = new ActuatorTimeLimited(boolAct, 2, 5);
-    ActuatorPwm * pwmAct = new ActuatorPwm(timeLimitedAct, 20);
+    std::shared_ptr<ActuatorDigital> boolAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> timeLimitedAct = std::make_shared<ActuatorTimeLimited>(boolAct, 2, 5);
+    std::shared_ptr<ActuatorPwm> pwmAct = std::make_shared<ActuatorPwm>(timeLimitedAct, 20);
 
     pwmAct->setValue(5.0); // set to a value with duty cycle lower than time limit
     ticks_millis_t start = ticks.millis();
@@ -613,13 +613,13 @@ BOOST_AUTO_TEST_CASE(decreasing_pwm_value_after_long_high_time_and_mutex_wait){
     mutex->setDeadTime(100000);
 
     // actuator that prevents other actuator from going high
-    ActuatorDigital * blocker = new ActuatorBool();
-    ActuatorMutexDriver * blockerMutex = new ActuatorMutexDriver(blocker, mutex);
+    std::shared_ptr<ActuatorDigital> blocker = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorMutexDriver> blockerMutex = std::make_shared<ActuatorMutexDriver>(blocker, mutex);
 
 
-    ActuatorDigital * boolAct = new ActuatorBool();
-    ActuatorMutexDriver * mutexAct = new ActuatorMutexDriver(boolAct, mutex);
-    ActuatorPwm * pwmAct = new ActuatorPwm(mutexAct, 20);
+    std::shared_ptr<ActuatorDigital> boolAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorMutexDriver> mutexAct = std::make_shared<ActuatorMutexDriver>(boolAct, mutex);
+    std::shared_ptr<ActuatorPwm> pwmAct = std::make_shared<ActuatorPwm>(mutexAct, 20);
 
     ticks_millis_t start = ticks.millis();
 
@@ -665,14 +665,14 @@ BOOST_AUTO_TEST_CASE(decreasing_pwm_value_after_long_high_time_and_mutex_wait){
 BOOST_AUTO_TEST_CASE(install_and_uninstall_final_actuator){
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
     mutex->setDeadTime(1000);
-    ActuatorDigital * coolerPin = new ActuatorBool();
-    ActuatorTimeLimited * coolerTimeLimited = new ActuatorTimeLimited(coolerPin, 120, 180); // 2 min minOn time, 3 min minOff
-    ActuatorMutexDriver * coolerMutex = new ActuatorMutexDriver(coolerTimeLimited, mutex);
-    ActuatorPwm * cooler = new ActuatorPwm(coolerMutex, 10); // period 10 min
+    std::shared_ptr<ActuatorDigital> coolerPin = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorTimeLimited> coolerTimeLimited = std::make_shared<ActuatorTimeLimited>(coolerPin, 120, 180); // 2 min minOn time, 3 min minOff
+    std::shared_ptr<ActuatorMutexDriver> coolerMutex = std::make_shared<ActuatorMutexDriver>(coolerTimeLimited, mutex);
+    std::shared_ptr<ActuatorPwm> cooler = std::make_shared<ActuatorPwm>(coolerMutex, 10); // period 10 min
 
-    ActuatorDigital * heaterPin = new ActuatorBool();
-    ActuatorMutexDriver * heaterMutex = new ActuatorMutexDriver(heaterPin, mutex);
-    ActuatorPwm * heater = new ActuatorPwm(heaterMutex, 4); // period 4s
+    std::shared_ptr<ActuatorDigital> heaterPin = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorMutexDriver> heaterMutex = std::make_shared<ActuatorMutexDriver>(heaterPin, mutex);
+    std::shared_ptr<ActuatorPwm> heater = std::make_shared<ActuatorPwm>(heaterMutex, 4); // period 4s
 
     BOOST_CHECK_EQUAL(coolerTimeLimited->getTarget(), coolerPin);
 
@@ -708,8 +708,8 @@ BOOST_AUTO_TEST_CASE(install_and_uninstall_final_actuator){
     BOOST_CHECK(!cooler->uninstallActuatorFinalTarget()); // returns false, when target is already default actuator
     BOOST_CHECK(!heater->uninstallActuatorFinalTarget()); // returns false, when target is already default actuator
 
-    coolerPin = new ActuatorBool(); // uninstall deleted the previous instance, need to recreate!
-    heaterPin = new ActuatorBool(); // uninstall deleted the previous instance, need to recreate!
+    coolerPin = std::make_shared<ActuatorBool>(); // uninstall deleted the previous instance, need to recreate!
+    heaterPin = std::make_shared<ActuatorBool>(); // uninstall deleted the previous instance, need to recreate!
 
     BOOST_CHECK(cooler->installActuatorFinalTarget(coolerPin)); // returns true on successful install
     BOOST_CHECK(heater->installActuatorFinalTarget(heaterPin)); // returns true on successful install

--- a/boost_test/ActuatorTimeLimitedTest.cpp
+++ b/boost_test/ActuatorTimeLimitedTest.cpp
@@ -35,12 +35,12 @@ BOOST_AUTO_TEST_SUITE(ActuatorTimeLimited_with_bool_driver)
 BOOST_AUTO_TEST_CASE(minimum_off_time_and_maximum_on_time_are_honored) {
     srand(time(NULL));
     ticks.reset();
-    ActuatorDigital * v = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> v = std::make_shared<ActuatorBool>();
     const uint16_t minOn = 100;
     const uint16_t maxOn = 200;
     const uint16_t minOff = 300;
 
-    ActuatorTimeLimited * act = new ActuatorTimeLimited(v, minOn, minOff, maxOn);
+    std::shared_ptr<ActuatorTimeLimited> act = std::make_shared<ActuatorTimeLimited>(v, minOn, minOff, maxOn);
 
 
     output << "\n\n**** Testing min OFF and max ON time for ActuatorTimeLimited ****\n\n";
@@ -79,12 +79,12 @@ BOOST_AUTO_TEST_CASE(minimum_off_time_and_maximum_on_time_are_honored) {
 BOOST_AUTO_TEST_CASE(minimum_on_time_is_honored) {
     srand(time(NULL));
     ticks.reset();
-    ActuatorDigital * v = new ActuatorBool();
+    std::shared_ptr<ActuatorDigital> v = std::make_shared<ActuatorBool>();
     const uint16_t minOn = 100;
     const uint16_t maxOn = 200;
     const uint16_t minOff = 300;
 
-    ActuatorTimeLimited * act = new ActuatorTimeLimited(v, minOn, minOff, maxOn);
+    std::shared_ptr<ActuatorTimeLimited> act = std::make_shared<ActuatorTimeLimited>(v, minOn, minOff, maxOn);
 
     output << ("\n\n**** Testing min ON time for ActuatorTimeLimited ****\n\n");
     ticks_seconds_t time;
@@ -105,12 +105,12 @@ BOOST_AUTO_TEST_CASE(minimum_on_time_is_honored) {
 }
 
 BOOST_AUTO_TEST_CASE(correct_state_is_returned_with_actuatorNop) {
-    ActuatorDigital * v = new ActuatorNop();
+    std::shared_ptr<ActuatorDigital> v = std::make_shared<ActuatorNop>();
     const uint16_t minOn = 100;
     const uint16_t maxOn = 200;
     const uint16_t minOff = 300;
 
-    ActuatorTimeLimited * act = new ActuatorTimeLimited(v, minOn, minOff, maxOn);
+    std::shared_ptr<ActuatorTimeLimited> act = std::make_shared<ActuatorTimeLimited>(v, minOn, minOff, maxOn);
 
     act->setActive(false); // make sure cached state is correct
     BOOST_CHECK(!act->isActive());

--- a/boost_test/DefaultDevicesTest.cpp
+++ b/boost_test/DefaultDevicesTest.cpp
@@ -44,9 +44,9 @@ BOOST_AUTO_TEST_CASE(defaultSetPoint_works_for_all_SetPoint_functions){
 }
 
 BOOST_AUTO_TEST_CASE(defaultLinearActuator_works_for_all_ActuatorRange_functions){
-    ActuatorRange * act = defaultLinearActuator();
+    std::shared_ptr<ActuatorRange> act = defaultLinearActuator();
 
-    BOOST_CHECK_EQUAL(act->getBareActuator(), act);
+    BOOST_CHECK_EQUAL(act->getBareActuator(), act.get());
     BOOST_CHECK_EQUAL(act->type(), ACTUATOR_RANGE);
 
     BOOST_CHECK_EQUAL(act->getValue(), temp_t::invalid());

--- a/boost_test/EsjTest.cpp
+++ b/boost_test/EsjTest.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <boost/test/unit_test.hpp>
-
 #include "runner.h"
 #include <string>
 
@@ -38,10 +37,10 @@
 BOOST_AUTO_TEST_SUITE(EsjTest)
 
 BOOST_AUTO_TEST_CASE(serialize_nested_actuators) {
-    //ActuatorBool * actBool = new ActuatorBool();
-    //ActuatorTimeLimited * actTl = new ActuatorTimeLimited(actBool, 10, 20);
-    ActuatorBool * boolAct1 = new ActuatorBool();
-    ActuatorMutexDriver * mutexAct1 = new ActuatorMutexDriver(boolAct1);
+    //std::shared_ptr<ActuatorBool> actBool = std::make_shared<ActuatorBool>();
+    //std::shared_ptr<ActuatorTimeLimited> actTl = std::make_shared<ActuatorTimeLimited>(actBool, 10, 20);
+    std::shared_ptr<ActuatorBool> boolAct1 = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorMutexDriver> mutexAct1 = std::make_shared<ActuatorMutexDriver>(boolAct1);
     ActuatorPwm * act1 = new ActuatorPwm (mutexAct1, 20);
 
     std::string json;
@@ -74,16 +73,16 @@ BOOST_AUTO_TEST_CASE(serialize_nested_actuators) {
 }
 
 BOOST_AUTO_TEST_CASE(serialize_nested_actuators2) {
-    ActuatorDigital* coolerPin = new ActuatorBool();
-    ActuatorDigital* coolerTimeLimited = new ActuatorTimeLimited(coolerPin, 120, 180); // 2 min minOn time, 3 min minOff
+    std::shared_ptr<ActuatorDigital> coolerPin = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorDigital> coolerTimeLimited = std::make_shared<ActuatorTimeLimited>(coolerPin, 120, 180); // 2 min minOn time, 3 min minOff
     ActuatorMutexGroup * mutex = new ActuatorMutexGroup();
-    ActuatorDigital* coolerMutex = new ActuatorMutexDriver(coolerTimeLimited, mutex);
-    ActuatorRange* cooler = new ActuatorPwm(coolerMutex, 600); // period 10 min
+    std::shared_ptr<ActuatorDigital> coolerMutex = std::make_shared<ActuatorMutexDriver>(coolerTimeLimited, mutex);
+    std::shared_ptr<ActuatorRange> cooler = std::make_shared<ActuatorPwm>(coolerMutex, 600); // period 10 min
 
 
     std::string json;
 
-    json = JSON::producer<ActuatorRange>::convert(cooler);
+    json = JSON::producer<ActuatorRange>::convert(cooler.get());
 
 /* With some extra whitespace, the valid output looks like this:
 {
@@ -164,10 +163,10 @@ BOOST_AUTO_TEST_CASE(serialize_ActuatorSetPoint) {
     SetPoint * sp1 = new SetPointSimple();
     SetPoint * sp2 = new SetPointConstant(20.0);
     TempSensorBasic * sens1 = new TempSensorMock(20.0);
-    ActuatorRange * act = new ActuatorSetPoint(sp1, sens1, sp2, -10.0, 10.0);
+    std::shared_ptr<ActuatorRange> act = std::make_shared<ActuatorSetPoint>(sp1, sens1, sp2, -10.0, 10.0);
     act->setValue(5.0); // should set sp1 to sp2 + 5.0 = 25.0;
 
-    std::string json = JSON::producer<ActuatorRange>::convert(act);
+    std::string json = JSON::producer<ActuatorRange>::convert(act.get());
 
 /* With some extra whitespace, the valid output looks like this:
     {
@@ -203,8 +202,8 @@ BOOST_AUTO_TEST_CASE(serialize_ActuatorSetPoint) {
 
 BOOST_AUTO_TEST_CASE(serialize_Pid) {
     TempSensorBasic * sensor = new TempSensorMock(20.0);
-    ActuatorDigital * boolAct = new ActuatorBool();
-    ActuatorRange * pwmAct = new ActuatorPwm(boolAct,4);
+    std::shared_ptr<ActuatorDigital> boolAct = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorRange> pwmAct = std::make_shared<ActuatorPwm>(boolAct,4);
     SetPoint * sp = new SetPointSimple(20.0);
     Pid * pid = new Pid(sensor, pwmAct, sp);
 

--- a/boost_test/PidTest.cpp
+++ b/boost_test/PidTest.cpp
@@ -42,8 +42,8 @@ public:
         BOOST_TEST_MESSAGE( "setup PID test fixture" );
 
         sensor = new TempSensorMock(20.0);
-        vAct = new ActuatorBool();
-        act = new ActuatorPwm(vAct,4);
+        vAct = std::make_shared<ActuatorBool>();
+        act = std::make_shared<ActuatorPwm>(vAct,4);
         sp = new SetPointSimple(20.0);
 
         pid = new Pid(sensor, act, sp);
@@ -51,14 +51,12 @@ public:
     ~PidTest(){
         BOOST_TEST_MESSAGE( "tear down PID test fixture" );
         delete sensor;
-        delete vAct;
-        delete act;
         delete pid;
     }
 
     TempSensorMock * sensor;
-    ActuatorDigital * vAct;
-    ActuatorPwm * act;
+    std::shared_ptr<ActuatorDigital> vAct;
+    std::shared_ptr<ActuatorRange> act;
     Pid * pid;
     SetPointSimple * sp;
 };
@@ -320,8 +318,8 @@ BOOST_AUTO_TEST_CASE(pid_can_update_with_only_actuator_defined){
 }
 
 BOOST_AUTO_TEST_CASE(pid_can_update_with_only_sensor_defined){
-    ActuatorDigital * pin = new ActuatorBool();
-    ActuatorRange * act = new ActuatorPwm(pin,4);
+    std::shared_ptr<ActuatorDigital> pin = std::make_shared<ActuatorBool>();
+    std::shared_ptr<ActuatorRange> act = std::make_shared<ActuatorPwm>(pin,4);
     Pid * p = new Pid();
     p->setOutputActuator(act);
     p->update();

--- a/boost_test/SimulationMashTest.cpp
+++ b/boost_test/SimulationMashTest.cpp
@@ -50,9 +50,9 @@ public:
 
         mutex = new ActuatorMutexGroup();
 
-        hltHeaterPin = new ActuatorBool();
-        hltHeaterMutex = new ActuatorMutexDriver(hltHeaterPin);
-        hltHeater = new ActuatorPwm(hltHeaterMutex, 4); // period 4s
+        hltHeaterPin = std::make_shared<ActuatorBool>();
+        hltHeaterMutex = std::make_shared<ActuatorMutexDriver>(hltHeaterPin);
+        hltHeater = std::make_shared<ActuatorPwm>(hltHeaterMutex, 4); // period 4s
 
         mashSet = new SetPointSimple(20.0);
         hltSet = new SetPointSimple(20.0);
@@ -60,7 +60,7 @@ public:
         hltHeaterPid = new Pid();
         mashToHltPid = new Pid();
 
-        hltSetPointActuator = new ActuatorSetPoint(hltSet, hltSensor, mashSet);
+        hltSetPointActuator = std::make_shared<ActuatorSetPoint>(hltSet, hltSensor, mashSet);
 
         hltHeaterPid->setOutputActuator(hltHeater);
         mashToHltPid->setOutputActuator(hltSetPointActuator);
@@ -69,12 +69,6 @@ public:
         BOOST_TEST_MESSAGE( "tear down mash test fixture" );
         delete mashSensor;
         delete hltSensor;
-
-        delete hltHeaterPin;
-        delete hltHeaterMutex;
-        delete hltHeater;
-
-        delete hltSetPointActuator;
 
         delete mutex;
 
@@ -89,11 +83,10 @@ public:
     TempSensorMock * mashSensor;
     TempSensorMock * hltSensor;
 
-    ActuatorDigital * hltHeaterPin;
-    ActuatorMutexDriver * hltHeaterMutex;
-    ActuatorRange * hltHeater;
-
-    ActuatorSetPoint * hltSetPointActuator;
+    std::shared_ptr<ActuatorDigital> hltHeaterPin;
+    std::shared_ptr<ActuatorDigital> hltHeaterMutex;
+    std::shared_ptr<ActuatorRange> hltHeater;
+    std::shared_ptr<ActuatorSetPoint> hltSetPointActuator;
 
     ActuatorMutexGroup * mutex;
 

--- a/boost_test/SimulationTest.cpp
+++ b/boost_test/SimulationTest.cpp
@@ -47,14 +47,14 @@ public:
         beerSensor = new TempSensorMock(20.0);
         fridgeSensor = new TempSensorMock(20.0);
 
-        heaterPin = new ActuatorBool();
-        heaterMutex = new ActuatorMutexDriver(heaterPin);
-        heater = new ActuatorPwm(heaterMutex, 20); // period 20s, because update steps are 1 second
+        heaterPin = std::make_shared<ActuatorBool>();
+        heaterMutex = std::make_shared<ActuatorMutexDriver>(heaterPin);
+        heater = std::make_shared<ActuatorPwm>(heaterMutex, 20); // period 20s, because update steps are 1 second
 
-        coolerPin = new ActuatorBool();
-        coolerTimeLimited = new ActuatorTimeLimited(coolerPin, 120, 180); // 2 min minOn time, 3 min minOff
-        coolerMutex = new ActuatorMutexDriver(coolerTimeLimited);
-        cooler = new ActuatorPwm(coolerMutex, 1200); // period 20 min
+        coolerPin = std::make_shared<ActuatorBool>();
+        coolerTimeLimited = std::make_shared<ActuatorTimeLimited>(coolerPin, 120, 180); // 2 min minOn time, 3 min minOff
+        coolerMutex = std::make_shared<ActuatorMutexDriver>(coolerTimeLimited);
+        cooler = std::make_shared<ActuatorPwm>(coolerMutex, 1200); // period 20 min
         mutex = new ActuatorMutexGroup();
 
         beerSet = new SetPointSimple(20.0);
@@ -64,7 +64,7 @@ public:
         coolerPid = new Pid();
         beerToFridgePid = new Pid();
 
-        fridgeSetPointActuator = new ActuatorSetPoint(fridgeSet, fridgeSensor, beerSet);
+        fridgeSetPointActuator = std::make_shared<ActuatorSetPoint>(fridgeSet, fridgeSensor, beerSet);
 
         heaterPid->setOutputActuator(heater);
         coolerPid->setOutputActuator(cooler);
@@ -75,18 +75,6 @@ public:
         BOOST_TEST_MESSAGE( "tear down PID test fixture" );
         delete beerSensor;
         delete fridgeSensor;
-
-        delete coolerPin;
-        delete coolerTimeLimited;
-        delete coolerMutex;
-        delete cooler;
-
-        delete heaterPin;
-        delete heaterMutex;
-        delete heater;
-
-        delete fridgeSetPointActuator;
-
         delete mutex;
 
         delete heaterPid;
@@ -101,16 +89,16 @@ public:
     TempSensorMock * beerSensor;
     TempSensorMock * fridgeSensor;
 
-    ActuatorDigital * coolerPin;
-    ActuatorDigital * coolerTimeLimited;
-    ActuatorMutexDriver * coolerMutex;
-    ActuatorRange * cooler;
+    std::shared_ptr<ActuatorDigital> coolerPin;
+    std::shared_ptr<ActuatorDigital> coolerTimeLimited;
+    std::shared_ptr<ActuatorMutexDriver> coolerMutex;
+    std::shared_ptr<ActuatorRange> cooler;
 
-    ActuatorDigital * heaterPin;
-    ActuatorMutexDriver * heaterMutex;
-    ActuatorRange * heater;
+    std::shared_ptr<ActuatorDigital> heaterPin;
+    std::shared_ptr<ActuatorMutexDriver> heaterMutex;
+    std::shared_ptr<ActuatorRange> heater;
 
-    ActuatorSetPoint * fridgeSetPointActuator;
+    std::shared_ptr<ActuatorSetPoint> fridgeSetPointActuator;
 
     ActuatorMutexGroup * mutex;
 

--- a/lib/inc/ActuatorBottom.h
+++ b/lib/inc/ActuatorBottom.h
@@ -29,10 +29,10 @@ public:
 protected:
     ~ActuatorBottom() = default;
 public:
-    Actuator * getBareActuator() final {
+    const Actuator * getBareActuator() const final {
         return this;  // recursive call for composite driver classes, until a non-driver class is reached
     }
-    bool installActuatorFinalTarget(ActuatorDigital * a) final {
+    bool installActuatorFinalTarget(const std::shared_ptr<ActuatorDigital> & a) final {
         return false; // does nothing for non-driver actuators
     }
 

--- a/lib/inc/ActuatorDriver.h
+++ b/lib/inc/ActuatorDriver.h
@@ -32,10 +32,10 @@
 class ActuatorDriver : public virtual Actuator
 {
 protected:
-    ActuatorDigital * target;
+    std::shared_ptr<ActuatorDigital> target;
 
 public:
-    ActuatorDriver(ActuatorDigital * _target) : target(_target){}
+    ActuatorDriver(std::shared_ptr<ActuatorDigital> _target) : target(_target){}
 protected:
     ~ActuatorDriver() = default; // should not be destructed through this base class
 
@@ -44,25 +44,22 @@ public:
         target->update();
     }
 
-    ActuatorDigital * getTarget(){ return target; }
+    std::shared_ptr<ActuatorDigital> & getTarget() { return target; }
 
-    Actuator * getBareActuator() final {
-        if( target->getBareActuator() == target){
-            return target; // my target is bottom
+    const Actuator * getBareActuator() const final {
+        if( target->getBareActuator() == target.get()){
+            return target.get(); // my target is bottom
         }
         else{
             return target->getBareActuator(); // my target is not bottom
         }
     }
 
-    bool installActuatorFinalTarget(ActuatorDigital * a) final{
-        if(target->getBareActuator() == target){
+    bool installActuatorFinalTarget(const std::shared_ptr<ActuatorDigital> & a) final{
+        if(target->getBareActuator() == target.get()){
             // I am the lowest level driver. my target is the bottom target
             if(target == a){
                 return false; // actuator was already installed
-            }
-            if(target != defaultActuator()){
-                delete target; // target is only referenced here and should be deleted
             }
             target = a;
             return true; // installed new actuator

--- a/lib/inc/ActuatorInterfaces.h
+++ b/lib/inc/ActuatorInterfaces.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <memory>
 #include "temperatureFormats.h"
 #include "json_adapter.h"
 #include "ControllerMixins.h"
@@ -50,10 +51,10 @@ public:
 	// next 3 functions are implemented by ActuatorDriver or ActuatorBottom
 
 	// recursive call for composite driver classes, until a non-driver class is reached
-	virtual Actuator * getBareActuator() = 0;
+	virtual const Actuator * getBareActuator() const = 0;
 	// install pin/mock actuator at the lowest level, returns Actuator that was installed
 	    // Returns true if a device was uninstalled, so the driver knows to update its own pointer
-	virtual bool installActuatorFinalTarget(ActuatorDigital * a) = 0;
+	virtual bool installActuatorFinalTarget(const std::shared_ptr<ActuatorDigital> & a) = 0;
 	// uninstall pi n/mock actuator at the lowest level, return success (true = an actuator was uninstalled)
 	virtual bool uninstallActuatorFinalTarget() = 0;
 

--- a/lib/inc/ActuatorMutexDriver.h
+++ b/lib/inc/ActuatorMutexDriver.h
@@ -31,8 +31,8 @@
 
 class ActuatorMutexDriver final : public ActuatorDriver, public ActuatorDigital, public ActuatorMutexDriverMixin{
 public:
-    ActuatorMutexDriver(ActuatorDigital * target) : ActuatorDriver(target), mutexGroup(nullptr){}
-    ActuatorMutexDriver(ActuatorDigital * target, ActuatorMutexGroup * m) : ActuatorDriver(target), mutexGroup(m){}
+    ActuatorMutexDriver(std::shared_ptr<ActuatorDigital> target) : ActuatorDriver(target), mutexGroup(nullptr){}
+    ActuatorMutexDriver(std::shared_ptr<ActuatorDigital> target, ActuatorMutexGroup * m) : ActuatorDriver(target), mutexGroup(m){}
 
     ~ActuatorMutexDriver(){
         setMutex(nullptr);

--- a/lib/inc/ActuatorPwm.h
+++ b/lib/inc/ActuatorPwm.h
@@ -45,7 +45,7 @@ class ActuatorPwm final : public ActuatorDriver, public ActuatorRange, public Ac
         temp_t         maxVal;
 
     public:
-        ActuatorPwm(ActuatorDigital * _target, uint16_t _period);
+        ActuatorPwm(std::shared_ptr<ActuatorDigital> _target, uint16_t _period);
 
         ~ActuatorPwm() = default;
 
@@ -72,7 +72,7 @@ class ActuatorPwm final : public ActuatorDriver, public ActuatorRange, public Ac
             return period_ms / 1000; // return in seconds, same as set period
         }
 
-        void setTarget(ActuatorDigital * t)
+        void setTarget(std::shared_ptr<ActuatorDigital> t)
         {
             target = t;
         }

--- a/lib/inc/ActuatorTimeLimited.h
+++ b/lib/inc/ActuatorTimeLimited.h
@@ -31,7 +31,7 @@
 class ActuatorTimeLimited final : public ActuatorDriver, public ActuatorDigital, public ActuatorTimeLimitedMixin
 {
 public:
-    ActuatorTimeLimited(ActuatorDigital * _target,
+    ActuatorTimeLimited(std::shared_ptr<ActuatorDigital> _target,
             ticks_seconds_t   _minOnTime = 120,
             ticks_seconds_t   _minOffTime = 180,
             ticks_seconds_t   _maxOnTime = UINT16_MAX) : ActuatorDriver(_target)

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -33,7 +33,7 @@ class Pid final : public PidMixin
 {
 
     public:
-        Pid(TempSensorBasic * input, ActuatorRange * output, SetPoint * setPoint);
+        Pid(TempSensorBasic * input, std::shared_ptr<ActuatorRange> output, SetPoint * setPoint);
 
         Pid() : Pid(defaultTempSensorBasic(), defaultLinearActuator(), defaultSetPoint()){}
 
@@ -63,9 +63,9 @@ class Pid final : public PidMixin
             return inputSensor;
         }
 
-        bool setOutputActuator(ActuatorRange * a);
+        bool setOutputActuator(std::shared_ptr<ActuatorRange> a);
 
-        ActuatorRange * getOutputActuator(){
+        const std::shared_ptr<ActuatorRange> & getOutputActuator(){
             return outputActuator;
         }
 
@@ -109,7 +109,7 @@ class Pid final : public PidMixin
         */
 
     protected:
-        ActuatorRange *   outputActuator;
+        std::shared_ptr<ActuatorRange> outputActuator;
         TempSensorBasic * inputSensor;
         SetPoint *        setPoint;
         temp_long_t       Kp;    // proportional gain

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -3,7 +3,7 @@
 #include "Ticks.h"
 #include "ActuatorMutexDriver.h"
 
-ActuatorPwm::ActuatorPwm(ActuatorDigital* _target, uint16_t _period) :
+ActuatorPwm::ActuatorPwm(std::shared_ptr<ActuatorDigital> _target, uint16_t _period) :
     ActuatorDriver(_target) {
     periodStartTime = ticks.millis();
     periodLate = 0;
@@ -151,7 +151,7 @@ void ActuatorPwm::update() {
         }
         if(goHigh){
             if(target->type() == ACTUATOR_TOGGLE_MUTEX){
-                static_cast<ActuatorMutexDriver*>(target)->setActive(true, priority());
+                std::static_pointer_cast<ActuatorMutexDriver>(target)->setActive(true, priority());
             }
             else{
                 target->setActive(true);

--- a/lib/src/Pid.cpp
+++ b/lib/src/Pid.cpp
@@ -22,7 +22,7 @@
 #include "Pid.h"
 
 Pid::Pid(TempSensorBasic * input,
-         ActuatorRange * output,
+         std::shared_ptr<ActuatorRange> output,
          SetPoint * setPoint)
 {
     setConstants(temp_t(0.0), 0, 0);
@@ -212,7 +212,7 @@ bool Pid::setInputSensor(TempSensorBasic * s)
     return true;
 }
 
-bool Pid::setOutputActuator(ActuatorRange * a)
+bool Pid::setOutputActuator(std::shared_ptr<ActuatorRange> a)
 {
     outputActuator = a;
 


### PR DESCRIPTION
This PR is meant for discussion and should not be merged.

I have changed the actuator pointers from bare pointers to std::shared_ptr.
The tests compile and succeed. The Core/Photon builds have not been fixed to compile .

While this was an interesting exercise, I doubt it is the right way forward.

Instead of sharing ownership between all objects interacting with an actuator (e.g. Control, PID and driver actuators), it would be better to use unique_ptr and have one true owner (the container). All other objects should reference the target actuator through this one true owner.

However, we might end up implementing a ref counting scheme similar to shared_ptr, to decide whether an object is not in use anymore and can be deleted.

If objects needing access to an actuator keep it as a reference member, do we only allow setting the reference during construction?

Articles worth reading:
http://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/
http://herbsutter.com/2013/05/29/gotw-89-solution-smart-pointers/
http://stackoverflow.com/questions/892133/should-i-prefer-pointers-or-references-in-member-data
