### PR TITLE
 worked out idea for templated containers holding a unique_ptr<T>

### DIFF
--- a/app/controller/SmartPtrContainer.h
+++ b/app/controller/SmartPtrContainer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+#include "json_writer.h"
+
+// Some container manager dispatches IDs
+uint16_t getContainerId();
+
+// generic part for every container
+class SmartPtrContainerBase
+{
+public:
+    SmartPtrContainerBase(){
+        id = getContainerId();
+    };
+    virtual ~SmartPtrContainerBase(){
+        // search other containers for references to me (by unique ID) and invalidate these
+        // by setting the reference to default containers
+    }
+
+    virtual void serialize(JSON::Adapter & adapter) = 0;
+
+    // some generic variables in each container
+    uint16_t id;
+
+    // serializing these generic variables
+    void serializeHeader(JSON::Adapter & adapter) {
+        uint16_t id = this->id; // quick hack to work around ESJ template resolution failing with const vars
+        JSON_E(adapter, id);
+    }
+};
+
+// templated container part to wrap specific class
+template<class T>
+class SmartPtrContainer : public SmartPtrContainerBase, public std::unique_ptr<T>{
+public:
+    using std::unique_ptr<T>::unique_ptr;
+    virtual ~SmartPtrContainer() = default;
+
+    virtual void serialize(JSON::Adapter & adapter) final;
+};

--- a/app/controller/SmartPtrContainerDemo.cpp
+++ b/app/controller/SmartPtrContainerDemo.cpp
@@ -1,0 +1,49 @@
+/*
+* Copyright 2016 BrewPi/Elco Jacobs.
+*
+* This file is part of BrewPi.
+*
+* BrewPi is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* BrewPi is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "SmartPtrContainerDemo.h"
+
+// macro to easily output a data member behind a smart pointer, PE is with trailing comma, PT without
+#define JSON_PE(json_writer,class_member)  JSON::stream(json_writer,_ASTRING(#class_member),get()->class_member,true)
+#define JSON_PT(json_writer,class_member)  JSON::stream(json_writer,_ASTRING(#class_member),get()->class_member,false)
+
+
+uint16_t getContainerId(){
+    static uint16_t counter = 0;
+    return counter ++;
+}
+
+template<>
+void SmartPtrContainer<TestTarget>::serialize(JSON::Adapter & adapter){
+    JSON::Class root(adapter, "TestTarget");
+    serializeHeader(adapter);
+    JSON_PT(adapter, b);
+}
+
+template<>
+void SmartPtrContainer<TestDriver>::serialize(JSON::Adapter & adapter){
+    JSON::Class root(adapter, "TestDriver");
+    serializeHeader(adapter);
+    JSON_PE(adapter, a);
+    JSON_PE(adapter, target);
+    int16_t ab = get()->calc();
+    JSON_T(adapter, ab);
+}
+
+

--- a/app/controller/SmartPtrContainerDemo.h
+++ b/app/controller/SmartPtrContainerDemo.h
@@ -1,0 +1,32 @@
+#include "SmartPtrContainer.h"
+
+class TestTarget;
+template class SmartPtrContainer<TestTarget>;
+
+class TestTarget{
+public:
+    TestTarget(int b_) : b(b_){}
+    ~TestTarget() = default;
+
+    int16_t b;
+};
+
+class TestDriver;
+template class SmartPtrContainer<TestDriver>;
+
+class TestDriver{
+    using CtTestTarget = SmartPtrContainer<TestTarget>;
+
+public:
+   TestDriver(CtTestTarget & target_) : target(target_), a(1){
+    }
+    ~TestDriver() = default;
+
+   CtTestTarget & target;
+   int16_t a;
+
+   int16_t calc(){
+       return a * target->b; // demo using reference as if it was a raw pointer to TestTarget
+   }
+};
+

--- a/boost_test/SmartPtrContainerTest.cpp
+++ b/boost_test/SmartPtrContainerTest.cpp
@@ -1,0 +1,58 @@
+/*
+* Copyright 2016 BrewPi/Elco Jacobs.
+*
+* This file is part of BrewPi.
+*
+* BrewPi is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* BrewPi is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with BrewPi.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <boost/algorithm/string/erase.hpp>
+
+#include "runner.h"
+#include <string>
+
+#include "../app/controller/SmartPtrContainerDemo.h"
+#include "json_writer.h"
+
+BOOST_AUTO_TEST_SUITE(SmartPtrContainerTest)
+
+BOOST_AUTO_TEST_CASE(serialize_test_objects) {
+
+    SmartPtrContainer<TestTarget> target(new TestTarget(2));
+    SmartPtrContainer<TestDriver> driver(new TestDriver(target));
+
+    std::string json;
+    json = JSON::producer<SmartPtrContainer<TestDriver>>::convert(driver);
+
+    // Valid output looks like this with whitespace:
+    std::string valid =
+    R"({                             )"
+    R"(    "kind": "TestDriver",     )"
+    R"(    "id": 1,                  )"
+    R"(    "a": 1,                   )"
+    R"(    "target": {               )"
+    R"(        "kind": "TestTarget", )"
+    R"(        "id": 0,              )"
+    R"(        "b": 2                )"
+    R"(    },                        )"
+    R"(    "ab": 2                   )"
+    R"(}                             )";
+
+    erase_all(valid, " "); // remove spaces from valid string
+
+    BOOST_CHECK_EQUAL(valid, json);
+}
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/boost_test/makefile
+++ b/boost_test/makefile
@@ -51,6 +51,7 @@ CPPSRC += $(SOURCE_PATH)app/controller/defaultDevices.cpp
 CPPSRC += $(SOURCE_PATH)lib/src/ActuatorMutexGroup.cpp
 CPPSRC += $(SOURCE_PATH)app/controller/Control.cpp
 CPPSRC += $(SOURCE_PATH)lib/src/OneWireAddress.cpp
+CPPSRC += $(SOURCE_PATH)app/controller/SmartPtrContainerDemo.cpp
 
 ifeq ($(BOOST_ROOT),)
 $(error BOOST_ROOT not set. Download boost and add BOOST_ROOT to your environment variables.)


### PR DESCRIPTION
This is a minimal example on an idea I had for managing containers.

Each container inherits from unique_ptr:
- If the container is destroyed, what it points to is destroyed too
- A container can be moved, but not copied, it is unique and tied to its pointee
- The destructor of the container can look for other containers referencing it and change that reference to a default container for the specific class (default actuator, default sensor) before it is destroyed.
- The syntax for using a containerized target is still target->doSomething(), so not much rewriting needed.
- Functions that should be callable on all containers can go in the base container (possibly as virtual), as well as generic variables like the ID

Data type specific implementations can be declared as template specializations, like serialization, see SmartPtrContainerDemo.cpp.
