### PR TITLE
Watchdog to reset device if it hangs

### DIFF
--- a/platform/spark/modules/Platform.cpp
+++ b/platform/spark/modules/Platform.cpp
@@ -58,7 +58,7 @@ bool platform_init()
     return initialize;
 }
 
-#ifdef PLATFORM_THREADING
+#if PLATFORM_THREADING
 // Reset the system after 60 seconds if the application is unresponsive
 // The timeout of 60 seconds will reset automatically each time loop() is called, or manually by calling wd.checkin()
 ApplicationWatchdog appWatchdog(60000, System.reset);

--- a/platform/spark/modules/Platform.cpp
+++ b/platform/spark/modules/Platform.cpp
@@ -58,6 +58,12 @@ bool platform_init()
     return initialize;
 }
 
+#ifdef PLATFORM_THREADING
+// Reset the system after 60 seconds if the application is unresponsive
+// The timeout of 60 seconds will reset automatically each time loop() is called, or manually by calling wd.checkin()
+ApplicationWatchdog appWatchdog(60000, System.reset);
+#endif
+
 /**
  * In the cbox app, this is called as part of global construction, which is
  * too early for the gcc device to have feched the device id, so it's initialized

--- a/platform/spark/modules/Platform.h
+++ b/platform/spark/modules/Platform.h
@@ -36,6 +36,15 @@ struct data_block_ref {
 	size_t size;
 };
 
+
+#ifdef PLATFORM_THREADING
+extern ApplicationWatchdog appWatchdog;
+#else
+// define dummy watchdog checkin for when the watchdog is not available
+#define appWatchdog.checkin()
+#endif
+
+
 /**
  * Retrieves a pointer to the device id.
  */

--- a/platform/spark/modules/Platform.h
+++ b/platform/spark/modules/Platform.h
@@ -37,11 +37,14 @@ struct data_block_ref {
 };
 
 
-#ifdef PLATFORM_THREADING
+#if PLATFORM_THREADING
 extern ApplicationWatchdog appWatchdog;
+inline void watchdogCheckin(){
+	appWatchdog.checkin();
+}
 #else
 // define dummy watchdog checkin for when the watchdog is not available
-#define appWatchdog.checkin()
+inline void watchdogCheckin(){}
 #endif
 
 


### PR DESCRIPTION
When the device gets truly stuck (for example with read/write error in log), we need a hardware reset.

Particle offers an application watchdog implemented as a high priority FreeRTOS thread (ApplicationWatchdog).

From the particle docs:
"The application watchdog requires interrupts to be active in order to function. Enabling the hardware watchdog in combination with this is recommended, so that the system resets in the event that interrupts are not firing."

I agree with the statement above, but the particle docs give no hints on how to implement this hardware watchdog.

- This PR is to track status and should not be merged until the hardware watchdog has been implemented.
- This PR should be changed to be merged into develop when the display optimizations have been merged into it.