### PR TITLE
Fix memory leaks reported by valgrind when running test code

### DIFF
--- a/lib/inc/ActuatorMutexGroup.h
+++ b/lib/inc/ActuatorMutexGroup.h
@@ -31,7 +31,7 @@ public:
 	ActuatorPriority(ActuatorMutexDriver * act, int8_t p) : actuator(act), priority(p){};
 	~ActuatorPriority() = default;
     ActuatorMutexDriver * actuator;
-    int8_t priority; // valid priorities are 0-127, at -128 the actuator is removed from the group
+    int8_t priority; // valid priorities are 0-127. -1 is used for actuators that are not trying to get the mutex
 };
 
 class ActuatorMutexGroup final :

--- a/lib/src/ActuatorMutexDriver.cpp
+++ b/lib/src/ActuatorMutexDriver.cpp
@@ -1,0 +1,33 @@
+#include "ActuatorMutexDriver.h"
+#include "ActuatorMutexGroup.h"
+
+ActuatorMutexDriver::ActuatorMutexDriver(ActuatorDigital & target, ActuatorMutexGroup * m) : target(target), mutexGroup(m){
+	m->registerActuator(this);
+}
+
+void ActuatorMutexDriver::setMutex(ActuatorMutexGroup * mutex){
+	if(mutexGroup != nullptr){
+		mutexGroup->unRegisterActuator(this); // unregister at old group
+	}
+	if(mutex != nullptr){
+		mutex->registerActuator(this); // register at new group
+	}
+	mutexGroup = mutex;
+}
+
+// To activate actuator, permission is asked from mutexGroup, false is always allowed
+  // when priority not specified, default to highest priority
+void ActuatorMutexDriver::setState(State state, int8_t priority){
+  if(mutexGroup != nullptr){
+	  if(mutexGroup->request(this, state, priority)){
+		  target.setState(state);
+		  if(target.getState() != state){
+			  // if setting the target failed, cancel the request to prevent blocking other actuators
+			  mutexGroup->cancelRequest(this);
+		  }
+	  }
+  }
+  else{
+	  target.setState(state); // if mutex group is not set, just pass on the call
+  }
+}

--- a/lib/src/defaultDevices.cpp
+++ b/lib/src/defaultDevices.cpp
@@ -21,22 +21,22 @@
 #include "defaultDevices.h"
 
 ActuatorNop * defaultActuator(){
-    static ActuatorNop * a = new ActuatorNop;
-    return a;
+    static ActuatorNop a;
+    return &a;
 }
 
 ActuatorInvalid * defaultLinearActuator(){ // always returns invalid and does nothing
-    static ActuatorInvalid * a = new ActuatorInvalid;
-    return a;
+    static ActuatorInvalid a;
+    return &a;
 }
 
 
 TempSensorDisconnected * defaultTempSensor(){
-    static TempSensorDisconnected * t = new TempSensorDisconnected;
-    return t;
+    static TempSensorDisconnected t;
+    return &t;
 }
 
 SetPointConstant * defaultSetPoint(){
-    static SetPointConstant * sp = new SetPointConstant(temp_t::invalid());
-    return sp;
+    static SetPointConstant sp(temp_t::invalid());
+    return &sp;
 }

--- a/lib/test/ActuatorMocksTest.cpp
+++ b/lib/test/ActuatorMocksTest.cpp
@@ -37,6 +37,7 @@ BOOST_AUTO_TEST_CASE(ActuatorBoolTest) {
 
     act->setState(ActuatorDigital::State::Inactive);
     BOOST_CHECK(act->getState() == ActuatorDigital::State::Inactive); // can be set to inactive
+    delete act;
 }
 
 

--- a/lib/test/ActuatorMutexTest.cpp
+++ b/lib/test/ActuatorMutexTest.cpp
@@ -192,6 +192,21 @@ BOOST_AUTO_TEST_CASE(when_there_have_been_no_requests_for_a_while_dead_time_is_s
     BOOST_CHECK(act2.getState() == ActuatorDigital::State::Inactive); // not allowed, because of dead time
 }
 
+BOOST_AUTO_TEST_CASE(test_destructors1) {
+    auto act1 = new ActuatorBool();
+    auto act2 = new ActuatorBool();
+    auto mutex = new ActuatorMutexGroup();
+
+    auto actm1 = new ActuatorMutexDriver(*act1);
+    auto actm2 = new ActuatorMutexDriver(*act2);
+
+    delete mutex;
+    delete actm1;
+    delete actm2;
+    delete act1;
+    delete act2;
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/lib/test/ActuatorTimeLimitedTest.cpp
+++ b/lib/test/ActuatorTimeLimitedTest.cpp
@@ -43,7 +43,6 @@ BOOST_AUTO_TEST_CASE(minimum_off_time_and_maximum_on_time_are_honored) {
 
     ActuatorTimeLimited * act = new ActuatorTimeLimited(*v, minOn, minOff, maxOn);
 
-
     *output << "\n\n**** Testing min OFF and max ON time for ActuatorTimeLimited ****\n\n";
 
     while(ticks.seconds() < 10000) {
@@ -79,6 +78,9 @@ BOOST_AUTO_TEST_CASE(minimum_off_time_and_maximum_on_time_are_honored) {
             break;
         }
     }
+
+    delete v;
+    delete act;
 }
 
 BOOST_AUTO_TEST_CASE(minimum_on_time_is_honored) {
@@ -107,6 +109,9 @@ BOOST_AUTO_TEST_CASE(minimum_on_time_is_honored) {
         BOOST_REQUIRE(act->getState() == ActuatorDigital::State::Active);
     }
     *output << "Was ON for " << time - onMoment << "seconds\n";
+
+    delete v;
+	delete act;
 }
 
 BOOST_AUTO_TEST_CASE(correct_state_is_returned_with_actuatorNop) {
@@ -125,6 +130,9 @@ BOOST_AUTO_TEST_CASE(correct_state_is_returned_with_actuatorNop) {
     act->setState(ActuatorDigital::State::Active);
     // ActuatorNop cannot go active, so cached state state should stay inactive too.
     BOOST_CHECK(act->getState() == ActuatorDigital::State::Inactive);
+
+    delete v;
+	delete act;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/lib/test/RefToTest.cpp
+++ b/lib/test/RefToTest.cpp
@@ -135,6 +135,7 @@ BOOST_AUTO_TEST_CASE(RefTo_SetPointActuator) {
     RefTo<ActuatorAnalog> ref(lookup);
 
     BOOST_CHECK_EQUAL(ref.get(), spa);
+    delete spa;
 }
 
 

--- a/lib/test/TempSensorMockTest.cpp
+++ b/lib/test/TempSensorMockTest.cpp
@@ -30,6 +30,7 @@ BOOST_AUTO_TEST_CASE (mock_sensor_init){
     temp_t t = s->read();
 
     BOOST_CHECK_EQUAL(t, temp_t(20.0));
+    delete s;
 }
 
 BOOST_AUTO_TEST_CASE (unconnected_mock_sensor_will_return_invalid){
@@ -38,6 +39,7 @@ BOOST_AUTO_TEST_CASE (unconnected_mock_sensor_will_return_invalid){
     temp_t t = s->read();
 
     BOOST_CHECK_EQUAL(t, temp_t::invalid());
+    delete s;
 }
 
 BOOST_AUTO_TEST_CASE (unconnected_mock_sensor_will_false_on_init){
@@ -46,6 +48,7 @@ BOOST_AUTO_TEST_CASE (unconnected_mock_sensor_will_false_on_init){
 
     s->setConnected(false);
     BOOST_CHECK(!s->init());
+    delete s;
 }
 
 BOOST_AUTO_TEST_CASE(test_limited_precision){

--- a/lib/test/VisitorCastTest.cpp
+++ b/lib/test/VisitorCastTest.cpp
@@ -73,5 +73,9 @@ BOOST_AUTO_TEST_CASE(casting_interfaces_to_specialized_interfaces){
 
     act = asInterface<ActuatorAnalog>(_pwmAct);
     BOOST_REQUIRE_EQUAL(act, pwmAct);
+
+    delete _sensor;
+    delete _boolAct;
+    delete _pwmAct;
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR fixes invalid memory access reported by valgrind for lib test.

Apart from some missing deletes in test code, ActuatorMutexGroup had an invalid memory access. The class has been refactored and the new implementation reports no errors.