### PR TITLE
Object discovery

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -84,6 +84,25 @@
                 },
             ],
             "miDebuggerArgs": "-x ~/repos/firmware/tools/pretty.gdbinit"
-        }
+        },
+        {
+            "name": "controlbox unit tests",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/controlbox/build/runner",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
     ]
 }

--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -56,8 +56,8 @@ using TicksClass = Ticks<MockTicks>;
 #endif
 
 #if !defined(PLATFORM_ID) || PLATFORM_ID == 3
-#include "MockOneWireScanningFactory.h"
 #include "OneWireNull.h"
+#include "test/MockOneWireScanningFactory.h"
 using OneWireDriver = OneWireNull;
 #define ONEWIRE_ARG
 #else

--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -19,6 +19,7 @@
 
 #include "Board.h"
 #include "Logger.h"
+#include "OneWireScanningFactory.h"
 #include "blox/ActuatorAnalogMockBlock.h"
 #include "blox/ActuatorOffsetBlock.h"
 #include "blox/ActuatorPinBlock.h"
@@ -159,7 +160,10 @@ makeBrewBloxBox()
     static cbox::EepromObjectStorage objectStore(eeprom);
     static cbox::ConnectionPool& connections = theConnectionPool();
 
-    static cbox::Box box(objectFactory, objects, objectStore, connections);
+    std::vector<std::unique_ptr<cbox::ScanningFactory>> scanningFactories;
+    scanningFactories.push_back(std::unique_ptr<cbox::ScanningFactory>(new OneWireScanningFactory(objects, theOneWire())));
+
+    static cbox::Box box(objectFactory, objects, objectStore, connections, std::move(scanningFactories));
 
     return box;
 }

--- a/app/brewblox/BrewBlox.cpp
+++ b/app/brewblox/BrewBlox.cpp
@@ -19,7 +19,6 @@
 
 #include "Board.h"
 #include "Logger.h"
-#include "OneWireScanningFactory.h"
 #include "blox/ActuatorAnalogMockBlock.h"
 #include "blox/ActuatorOffsetBlock.h"
 #include "blox/ActuatorPinBlock.h"
@@ -57,11 +56,13 @@ using TicksClass = Ticks<MockTicks>;
 #endif
 
 #if !defined(PLATFORM_ID) || PLATFORM_ID == 3
+#include "MockOneWireScanningFactory.h"
 #include "OneWireNull.h"
 using OneWireDriver = OneWireNull;
 #define ONEWIRE_ARG
 #else
 #include "DS248x.h"
+#include "OneWireScanningFactory.h"
 using OneWireDriver = DS248x;
 #define ONEWIRE_ARG 0x00
 #endif
@@ -161,7 +162,11 @@ makeBrewBloxBox()
     static cbox::ConnectionPool& connections = theConnectionPool();
 
     std::vector<std::unique_ptr<cbox::ScanningFactory>> scanningFactories;
+#if PLATFORM_ID == 3
+    scanningFactories.push_back(std::unique_ptr<cbox::ScanningFactory>(new MockOneWireScanningFactory(objects, theOneWire())));
+#else
     scanningFactories.push_back(std::unique_ptr<cbox::ScanningFactory>(new OneWireScanningFactory(objects, theOneWire())));
+#endif
 
     static cbox::Box box(objectFactory, objects, objectStore, connections, std::move(scanningFactories));
 

--- a/app/brewblox/OneWireScanningFactory.h
+++ b/app/brewblox/OneWireScanningFactory.h
@@ -1,0 +1,68 @@
+#include "OneWire.h"
+#include "OneWireAddress.h"
+#include "OneWireDevice.h"
+#include "blox/TempSensorOneWireBlock.h"
+#include "cbox/Object.h"
+#include "cbox/ObjectContainer.h"
+#include "cbox/ScanningFactory.h"
+#include <memory>
+
+/**
+ * Simple mock factory that emulates object discovery
+ * Normally, a scanning factory will scan some type of communication bus
+ * This factory just has a list of candidates. If a LongIntObject with that value doesn't exist, it creates it.
+ */
+class OneWireScanningFactory : public cbox::ScanningFactory {
+private:
+    OneWire& bus;
+
+public:
+    OneWireScanningFactory(cbox::ObjectContainer& objects, OneWire& ow)
+        : cbox::ScanningFactory(objects)
+        , bus(ow)
+    {
+        reset();
+    }
+
+    virtual ~OneWireScanningFactory() = default;
+
+    virtual void reset() override final
+    {
+        bus.reset_search();
+    };
+    virtual std::shared_ptr<cbox::Object> scan() override final
+    {
+        auto newAddr = OneWireAddress();
+        while (true) {
+            if (bus.search(newAddr.asUint8ptr())) {
+                bool found = false;
+                for (auto existing = objectsRef.cbegin(); existing != objectsRef.cend(); ++existing) {
+                    OneWireDevice* ptrIfCorrectType = reinterpret_cast<OneWireDevice*>(existing->object()->implements(cbox::interfaceId<OneWireDevice>()));
+                    if (ptrIfCorrectType == nullptr) {
+                        continue; // not the right type, no match
+                    }
+                    if (ptrIfCorrectType->getDeviceAddress() == newAddr) {
+                        found = true; // object with value already exists
+                        break;
+                    }
+                }
+                if (!found) {
+                    // create new object
+                    uint8_t familyCode = newAddr.asUint8ptr()[0];
+                    switch (familyCode) {
+                    case DS18B20MODEL: {
+                        auto newSensor = std::make_shared<TempSensorOneWireBlock>();
+                        newSensor->get().setAddress(newAddr);
+                        return std::move(newSensor);
+                    }
+                    default:
+                        break;
+                    }
+                }
+            } else {
+                break;
+            }
+        };
+        return nullptr;
+    };
+};

--- a/app/brewblox/blox/BlockInterfaces.cpp
+++ b/app/brewblox/blox/BlockInterfaces.cpp
@@ -3,6 +3,7 @@
 #include "Balancer.h"
 #include "DigitalConstraints.pb.h"
 #include "FixedPoint.h"
+#include "OneWireDevice.h"
 #include "ProcessValue.h"
 #include "Setpoint.h"
 #include "SetpointSensorPair.h"

--- a/app/brewblox/blox/BlockInterfaces.cpp
+++ b/app/brewblox/blox/BlockInterfaces.cpp
@@ -68,4 +68,11 @@ interfaceIdImpl<Balancer<blox_DigitalConstraint_mutex_tag>>()
     return BrewbloxFieldOptions_LinkType_Balancer;
 }
 
+template <>
+const obj_type_t
+interfaceIdImpl<OneWireDevice>()
+{
+    return BrewbloxFieldOptions_LinkType_OneWireDevice;
+}
+
 } // end namespace cbox

--- a/app/brewblox/blox/SysInfoBlock.h
+++ b/app/brewblox/blox/SysInfoBlock.h
@@ -23,9 +23,6 @@
 #include "cbox/DataStream.h"
 #include "deviceid_hal.h"
 #include "proto/cpp/SysInfo.pb.h"
-#if defined(PLATFORM_ID) && PLATFORM_ID != 3
-#include "deviceid_hal.h"
-#endif
 
 // provides a protobuf interface to the read only system info
 class SysInfoBlock : public cbox::ObjectBase<blox_SysInfo_msgid> {

--- a/app/brewblox/blox/TempSensorOneWireBlock.h
+++ b/app/brewblox/blox/TempSensorOneWireBlock.h
@@ -66,8 +66,9 @@ public:
         }
         if (iface == cbox::interfaceId<OneWireDevice>()) {
             // return the member that implements the interface in this case
-            TempSensor* ptr = &sensor;
-            return ptr;
+            TempSensorOneWire* sensorPtr = &sensor;
+            OneWireDevice* devicePtr = sensorPtr;
+            return devicePtr;
         }
         return nullptr;
     }

--- a/app/brewblox/blox/TempSensorOneWireBlock.h
+++ b/app/brewblox/blox/TempSensorOneWireBlock.h
@@ -64,6 +64,11 @@ public:
             TempSensor* ptr = &sensor;
             return ptr;
         }
+        if (iface == cbox::interfaceId<OneWireDevice>()) {
+            // return the member that implements the interface in this case
+            TempSensor* ptr = &sensor;
+            return ptr;
+        }
         return nullptr;
     }
 

--- a/app/brewblox/proto/brewblox.proto
+++ b/app/brewblox/proto/brewblox.proto
@@ -13,6 +13,7 @@ message BrewbloxFieldOptions {
     ActuatorDigital = 6;
     Balancer = 7;
     Mutex = 8;
+    OneWireDevice = 9;
   }
   enum UnitType {
       NotSet = 0;

--- a/app/brewblox/test/MockOneWireScanningFactory.h
+++ b/app/brewblox/test/MockOneWireScanningFactory.h
@@ -1,0 +1,72 @@
+#include "OneWire.h"
+#include "OneWireAddress.h"
+#include "OneWireDevice.h"
+#include "blox/TempSensorOneWireBlock.h"
+#include "cbox/Object.h"
+#include "cbox/ObjectContainer.h"
+#include "cbox/ScanningFactory.h"
+#include <memory>
+#include <vector>
+
+/**
+ * Simple mock factory that emulates object discovery
+ * Normally, a scanning factory will scan some type of communication bus
+ * This factory just has a list of candidates. If a LongIntObject with that value doesn't exist, it creates it.
+ */
+class MockOneWireScanningFactory : public cbox::ScanningFactory {
+private:
+    OneWire& bus;
+    std::vector<OneWireAddress> adressesOnBus = {0x1111'1111'1111'1128, 0x2222'2222'2222'2228, 0x3333'3333'3333'3328, 0x1111'1111'1111'1128};
+    std::vector<OneWireAddress>::const_iterator nextAddress;
+
+public:
+    MockOneWireScanningFactory(cbox::ObjectContainer& objects, OneWire& ow)
+        : cbox::ScanningFactory(objects)
+        , bus(ow)
+    {
+        reset();
+    }
+
+    virtual ~MockOneWireScanningFactory() = default;
+
+    virtual void reset() override final
+    {
+        nextAddress = adressesOnBus.cbegin();
+    };
+    virtual std::shared_ptr<cbox::Object> scan() override final
+    {
+        while (true) {
+            if (nextAddress != adressesOnBus.cend()) {
+                bool found = false;
+                auto newAddr = *nextAddress;
+                ++nextAddress;
+                for (auto existing = objectsRef.cbegin(); existing != objectsRef.cend(); ++existing) {
+                    OneWireDevice* ptrIfCorrectType = reinterpret_cast<OneWireDevice*>(existing->object()->implements(cbox::interfaceId<OneWireDevice>()));
+                    if (ptrIfCorrectType == nullptr) {
+                        continue; // not the right type, no match
+                    }
+                    if (ptrIfCorrectType->getDeviceAddress() == newAddr) {
+                        found = true; // object with value already exists
+                        break;
+                    }
+                }
+                if (!found) {
+                    // create new object
+                    uint8_t familyCode = newAddr.asUint8ptr()[0];
+                    switch (familyCode) {
+                    case DS18B20MODEL: {
+                        auto newSensor = std::make_shared<TempSensorOneWireBlock>();
+                        newSensor->get().setAddress(newAddr);
+                        return std::move(newSensor);
+                    }
+                    default:
+                        break;
+                    }
+                }
+            } else {
+                break;
+            }
+        };
+        return nullptr;
+    };
+};

--- a/app/brewblox/test/runner.cpp
+++ b/app/brewblox/test/runner.cpp
@@ -1,7 +1,8 @@
 #define CATCH_CONFIG_MAIN
 
-#include <catch.hpp>
+#include "deviceid_hal.h"
 #include "testinfo.h"
+#include <catch.hpp>
 
 TestInfo testInfo;
 
@@ -10,3 +11,12 @@ handleReset(bool)
 {
     ++testInfo.rebootCount;
 };
+
+/* mock implementation for device ID */
+unsigned
+HAL_device_ID(uint8_t* dest, unsigned destLen)
+{
+    if (dest != nullptr && destLen != 0)
+        memset(dest, 0, destLen);
+    return destLen;
+}

--- a/controlbox/src/cbox/ObjectFactory.h
+++ b/controlbox/src/cbox/ObjectFactory.h
@@ -22,8 +22,6 @@
 
 #include "DataStream.h"
 #include "Object.h"
-#include <array>
-#include <functional>
 #include <memory>
 #include <tuple>
 #include <vector>

--- a/controlbox/src/cbox/ScanningFactory.h
+++ b/controlbox/src/cbox/ScanningFactory.h
@@ -1,0 +1,56 @@
+
+/*
+ * Copyright 2018 Elco Jacobs / BrewBlox, based on earlier work of Matthew McGowan
+ *
+ * This file is part of ControlBox.
+ *
+ * Controlbox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Controlbox.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Object.h"
+#include "ObjectContainer.h"
+#include <memory>
+
+namespace cbox {
+
+/**
+ * A scanning factory has some kind of scan mechanism for new objects.
+ * It has a reference to the object container to check if the new object already exists
+ */
+class ScanningFactory {
+protected:
+    ObjectContainer& objectsRef;
+
+public:
+    ScanningFactory(ObjectContainer& objects)
+        : objectsRef(objects)
+    {
+    }
+    virtual ~ScanningFactory() = default;
+
+    virtual void reset() = 0;
+    virtual std::shared_ptr<Object> scan() = 0;
+
+    obj_id_t scanAndAdd()
+    {
+        if (auto newObj = scan()) {
+            return objectsRef.add(newObj, uint8_t(0xFF));
+        }
+        return 0;
+    }
+};
+
+} // end namespace cbox

--- a/controlbox/test/Box_test.cpp
+++ b/controlbox/test/Box_test.cpp
@@ -10,60 +10,13 @@
 #include "ConnectionsStringStream.h"
 #include "DataStreamConverters.h"
 #include "EepromObjectStorage.h"
+#include "LongIntScanningFactory.h"
 #include "Object.h"
 #include "ObjectContainer.h"
 #include "ObjectFactory.h"
 #include "TestObjects.h"
 
 using namespace cbox;
-
-/**
- * Simple mock factory that emulates object discovery
- * Normally, a scanning factory will scan some type of communication bus
- * This factory just has a list of candidates. If a LongIntObject with that value doesn't exist, it creates it.
- */
-class LongIntScanningFactory : public ScanningFactory {
-private:
-    std::vector<uint32_t> candidates = {0x11111111, 0x22222222, 0x33333333, 0x44444444, 0x55555555};
-    std::vector<uint32_t>::const_iterator it;
-
-public:
-    LongIntScanningFactory(ObjectContainer& objects)
-        : ScanningFactory(objects)
-    {
-        reset();
-    }
-
-    virtual ~LongIntScanningFactory() = default;
-
-    virtual void reset() override final
-    {
-        it = candidates.cbegin();
-    };
-    virtual std::shared_ptr<Object> scan() override final
-    {
-        while (it != candidates.cend()) {
-            bool found = false;
-            uint32_t value = *it;
-            ++it;
-            for (auto existing = objectsRef.cbegin(); existing != objectsRef.cend(); ++existing) {
-                LongIntObject* ptrIfCorrectType = reinterpret_cast<LongIntObject*>(existing->object()->implements(LongIntObject::staticTypeId()));
-                if (ptrIfCorrectType == nullptr) {
-                    continue; // not the right type, no match
-                }
-                if (ptrIfCorrectType->value() == value) {
-                    found = true; // object with value already exists
-                    break;
-                }
-            }
-            if (!found) {
-                // create new object
-                return std::make_shared<LongIntObject>(value);
-            }
-        }
-        return nullptr;
-    };
-};
 
 SCENARIO("A controlbox Box")
 {

--- a/controlbox/test/LongIntScanningFactory.h
+++ b/controlbox/test/LongIntScanningFactory.h
@@ -1,0 +1,58 @@
+#include "Object.h"
+#include "ObjectContainer.h"
+#include "ScanningFactory.h"
+#include "TestObjects.h"
+#include <memory>
+#include <vector>
+
+namespace cbox {
+
+/**
+ * Simple mock factory that emulates object discovery
+ * Normally, a scanning factory will scan some type of communication bus
+ * This factory just has a list of candidates. If a LongIntObject with that value doesn't exist, it creates it.
+ */
+class LongIntScanningFactory : public ScanningFactory {
+private:
+    std::vector<uint32_t> candidates = {0x11111111, 0x22222222, 0x33333333, 0x44444444, 0x55555555};
+    std::vector<uint32_t>::const_iterator it;
+
+public:
+    LongIntScanningFactory(ObjectContainer& objects)
+        : ScanningFactory(objects)
+    {
+        reset();
+    }
+
+    virtual ~LongIntScanningFactory() = default;
+
+    virtual void reset() override final
+    {
+        it = candidates.cbegin();
+    };
+    virtual std::shared_ptr<Object> scan() override final
+    {
+        while (it != candidates.cend()) {
+            bool found = false;
+            uint32_t value = *it;
+            ++it;
+            for (auto existing = objectsRef.cbegin(); existing != objectsRef.cend(); ++existing) {
+                LongIntObject* ptrIfCorrectType = reinterpret_cast<LongIntObject*>(existing->object()->implements(LongIntObject::staticTypeId()));
+                if (ptrIfCorrectType == nullptr) {
+                    continue; // not the right type, no match
+                }
+                if (ptrIfCorrectType->value() == value) {
+                    found = true; // object with value already exists
+                    break;
+                }
+            }
+            if (!found) {
+                // create new object
+                return std::make_shared<LongIntObject>(value);
+            }
+        }
+        return nullptr;
+    };
+};
+
+} // end namespace cbox

--- a/lib/inc/OneWireDevice.h
+++ b/lib/inc/OneWireDevice.h
@@ -31,6 +31,7 @@ protected:
 
 public:
     OneWireAddress getDeviceAddress() const;
+    void setDeviceAddress(const OneWireAddress& addr);
     bool validAddress() const;
 
 protected:

--- a/lib/inc/TempSensorOneWire.h
+++ b/lib/inc/TempSensorOneWire.h
@@ -21,6 +21,7 @@
 
 #include "DallasTemperature.h"
 #include "OneWireAddress.h"
+#include "OneWireDevice.h"
 #include "TempSensor.h"
 #include "Temperature.h"
 
@@ -28,12 +29,11 @@ class OneWire;
 
 #define ONEWIRE_TEMP_SENSOR_PRECISION (4)
 
-class TempSensorOneWire final : public TempSensor {
+class TempSensorOneWire final : public TempSensor, public OneWireDevice {
 public:
 private:
     DallasTemperature sensor;
-    OneWireAddress sensorAddress = 0;
-    temp_t calibrationOffset = 0;
+    temp_t calibrationOffset;
     temp_t cachedValue = 0;
     bool connected = false;
 
@@ -45,17 +45,14 @@ public:
 	 *    on the bus is used.
 	 * /param calibration	A temperature value that is added to all readings. This can be used to calibrate the sensor.	 
 	 */
-    TempSensorOneWire(OneWire& bus, OneWireAddress _address, const temp_t& _calibrationOffset)
-        : sensor(&bus)
-        , sensorAddress(_address)
+    TempSensorOneWire(OneWire& bus, OneWireAddress _address = 0, const temp_t& _calibrationOffset = 0)
+        : OneWireDevice(bus, _address)
+        , sensor(&bus)
         , calibrationOffset(_calibrationOffset)
     {
-        init();
-    }
-
-    TempSensorOneWire(OneWire& bus)
-        : sensor(&bus)
-    {
+        if (_address) {
+            init();
+        }
     }
 
     ~TempSensorOneWire() = default;
@@ -70,7 +67,7 @@ public:
 
     void setAddress(OneWireAddress const& addr)
     {
-        sensorAddress = addr;
+        OneWireDevice::setDeviceAddress(addr);
     }
     void setCalibration(temp_t const& calib)
     {
@@ -78,7 +75,7 @@ public:
     }
     OneWireAddress getAddress() const
     {
-        return sensorAddress;
+        return OneWireDevice::getDeviceAddress();
     }
     temp_t getCalibration() const
     {

--- a/lib/src/OneWireDevice.cpp
+++ b/lib/src/OneWireDevice.cpp
@@ -31,6 +31,16 @@ OneWireDevice::getDeviceAddress() const
 }
 
 /**
+ * Set the device address
+ * @param new device address
+ */
+void
+OneWireDevice::setDeviceAddress(const OneWireAddress& addr)
+{
+    address = addr;
+}
+
+/**
  * Checks if the address is valid by performing a crc8 check on it
  * @return bool, true if valid
  */

--- a/lib/src/TempSensorOneWire.cpp
+++ b/lib/src/TempSensorOneWire.cpp
@@ -39,10 +39,10 @@ TempSensorOneWire::init()
 
     // If this is the first conversion after power on, the device will return DEVICE_DISCONNECTED_RAW
     // Because HIGH_ALARM_TEMP will be copied from EEPROM
-    int16_t temp = sensor.getTempRaw(sensorAddress.asUint8ptr());
+    int16_t temp = sensor.getTempRaw(getAddress().asUint8ptr());
     if (temp == DEVICE_DISCONNECTED_RAW) {
         // Device was just powered on and should be initialized
-        if (sensor.initConnection(sensorAddress.asUint8ptr())) {
+        if (sensor.initConnection(getAddress().asUint8ptr())) {
             requestConversion();
         }
     }
@@ -51,7 +51,7 @@ TempSensorOneWire::init()
 void
 TempSensorOneWire::requestConversion()
 {
-    sensor.requestTemperaturesByAddress(sensorAddress.asUint8ptr());
+    sensor.requestTemperaturesByAddress(getAddress().asUint8ptr());
 }
 
 void
@@ -61,9 +61,9 @@ TempSensorOneWire::setConnected(bool _connected)
         return; // state stays the same
     }
     if (connected) {
-        CL_LOG_WARN("OneWire temp sensor connected: ") << sensorAddress;
+        CL_LOG_WARN("OneWire temp sensor connected: ") << getAddress();
     } else {
-        CL_LOG_WARN("OneWire temp sensor disconnected: ") << sensorAddress;
+        CL_LOG_WARN("OneWire temp sensor disconnected: ") << getAddress();
     }
 }
 
@@ -90,7 +90,7 @@ TempSensorOneWire::readAndConstrainTemp()
     int16_t tempRaw;
     bool success;
 
-    tempRaw = sensor.getTempRaw(sensorAddress.asUint8ptr());
+    tempRaw = sensor.getTempRaw(getAddress().asUint8ptr());
     success = tempRaw != DEVICE_DISCONNECTED_RAW;
 
     if (!success) {


### PR DESCRIPTION
For the user, setting up a new temperature sensor should be as easy as plugging it in and pushing a button.
This PR implements that.

Cbox:Box has a new command for discovering devices. Because the box knows nothing about possible devices or hardware bus scans that might provide them, this is abstracted behind a ScaningFactory class.
On construction, a vector of scanning factories can be passed to the box. These factories are responsible for scanning for new objects, detecting whether they already exist and adding them to the box if not.

Because detecting duplicates is very object type specific, I decided to leave that to the factory. To be able to do that, it receives a reference to the object container.
This moves duplicate detection and object creation to the application space, where the specifics are known.

This PR also adds the first object discovery factory in the brewblox app: a OneWire object discovery, currently only supporting DS18B20 sensors. The switch case can be expanded later to create different objects based on the family code.
