### PR TITLE
Use device ID as hostname

### DIFF
--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -59,6 +59,9 @@ watchdogCheckin()
 }
 #endif
 
+#define str(x) #x
+#define xstr(x) "x"
+
 void
 setup()
 {
@@ -74,16 +77,24 @@ setup()
     System.on(setup_update, watchdogCheckin);
 
     bool success = mdns.setHostname(System.deviceID());
-    if (success) {
-        success = mdns.addService("tcp", "http", 80, "brewblox-status");
-    }
     mdns.addTXTEntry("VERSION", "0.1.0");
     mdns.addTXTEntry("ID", System.deviceID());
-    if (success) {
-        success = mdns.addService("tcp", "brewblox", 8332, System.deviceID());
+    mdns.addTXTEntry("PLATFORM", xstr(PLATFORM_ID));
+    auto hw = String("Spark ");
+    switch (getSparkVersion()) {
+    case SparkVersion::V1:
+        hw += "1";
+        break;
+    case SparkVersion::V2:
+        hw += "2";
+        break;
+    case SparkVersion::V3:
+        hw += "3";
+        break;
     }
-    mdns.addTXTEntry("VERSION", "0.1.0");
-    mdns.addTXTEntry("ID", System.deviceID());
+    mdns.addTXTEntry("HW", hw);
+    success = success && mdns.addService("tcp", "http", 80, System.deviceID());
+    success = success && mdns.addService("tcp", "brewblox", 8332, System.deviceID());
 }
 
 void

--- a/app/brewblox/main.cpp
+++ b/app/brewblox/main.cpp
@@ -77,16 +77,19 @@ setup()
     if (success) {
         success = mdns.addService("tcp", "http", 80, "brewblox-status");
     }
+    mdns.addTXTEntry("VERSION", "0.1.0");
+    mdns.addTXTEntry("ID", System.deviceID());
     if (success) {
-        success = mdns.addService("tcp", "brewblox", 8332, "brewblox");
+        success = mdns.addService("tcp", "brewblox", 8332, System.deviceID());
     }
     mdns.addTXTEntry("VERSION", "0.1.0");
+    mdns.addTXTEntry("ID", System.deviceID());
 }
 
 void
 loop()
 {
-    if (!WiFi.ready()) {
+    if (!WiFi.ready() || WiFi.listening()) {
         if (!WiFi.connecting()) {
             WiFi.connect(WIFI_CONNECT_SKIP_LISTEN);
 #if PLATFORM_ID != PLATFORM_GCC
@@ -112,7 +115,9 @@ loop()
         }
     }
 
-    brewbloxBox().hexCommunicate();
+    if (!WiFi.listening()) {
+        brewbloxBox().hexCommunicate();
+    }
     updateBrewbloxBox();
     watchdogCheckin();
 }


### PR DESCRIPTION
Devices now identify as:
```
Service Type: _brewblox._tcp
Service Name: 3f0025000851353532343835
Domain Name: local
Interface: enp8s0 IPv4
Address: 3f0025000851353532343835.local/192.168.0.78:8332
TXT VERSION = 0.1.0
TXT ID = 3f0025000851353532343835
```

This resolves naming conflicts in DNS discovery.