### PR TITLE
serialize which constraints are blocking/limiting

### DIFF
--- a/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
@@ -8,8 +8,8 @@
 using Minimum = AAConstraints::Minimum<blox_AnalogConstraint_min_tag>;
 using Maximum = AAConstraints::Maximum<blox_AnalogConstraint_max_tag>;
 
-using Balanced_t = AAConstraints::Balanced<blox_AnalogConstraint_balancer_tag>;
-using Balancer_t = Balancer<blox_AnalogConstraint_balancer_tag>;
+using Balanced_t = AAConstraints::Balanced<blox_AnalogConstraint_balanced_tag>;
+using Balancer_t = Balancer<blox_AnalogConstraint_balanced_tag>;
 
 class CboxBalanced : public AAConstraints::Base {
 private:
@@ -39,6 +39,11 @@ public:
     {
         return m_balanced.constrain(val);
     }
+
+    AAConstraints::value_t granted() const
+    {
+        return m_balanced.granted();
+    }
 };
 
 void
@@ -57,8 +62,8 @@ setAnalogConstraints(const blox_AnalogConstraints& msg, ActuatorAnalogConstraine
             act.addConstraint(std::make_unique<Maximum>(
                 cnl::wrap<ActuatorAnalog::value_t>(constraintDfn.constraint.max)));
             break;
-        case blox_AnalogConstraint_balancer_tag:
-            act.addConstraint(std::make_unique<CboxBalanced>(objects, constraintDfn.constraint.balancer));
+        case blox_AnalogConstraint_balanced_tag:
+            act.addConstraint(std::make_unique<CboxBalanced>(objects, constraintDfn.constraint.balanced.balancerId));
             break;
         }
     }
@@ -86,9 +91,10 @@ getAnalogConstraints(blox_AnalogConstraints& msg, const ActuatorAnalogConstraine
             auto obj = reinterpret_cast<Maximum*>((*it).get());
             msg.constraints[i].constraint.max = cnl::unwrap(obj->max());
         } break;
-        case blox_AnalogConstraint_balancer_tag: {
+        case blox_AnalogConstraint_balanced_tag: {
             auto obj = reinterpret_cast<CboxBalanced*>((*it).get());
-            msg.constraints[i].constraint.balancer = obj->balancerId();
+            msg.constraints[i].constraint.balanced.balancerId = obj->balancerId();
+            msg.constraints[i].constraint.balanced.granted = cnl::unwrap(obj->granted());
         } break;
         }
         msg.constraints[i].limiting = act.limiting() & (uint8_t(1) << i);

--- a/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
@@ -73,7 +73,7 @@ getAnalogConstraints(blox_AnalogConstraints& msg, const ActuatorAnalogConstraine
     pb_size_t numConstraints = pb_size_t(sizeof(msg.constraints) / sizeof(msg.constraints[0]));
     for (pb_size_t i = 0; i < numConstraints; ++i, ++it) {
         if (it == constraints.cend()) {
-            return;
+            break;
         }
         auto constraintId = (*it)->id();
         msg.constraints[i].which_constraint = constraintId;
@@ -91,6 +91,8 @@ getAnalogConstraints(blox_AnalogConstraints& msg, const ActuatorAnalogConstraine
             msg.constraints[i].constraint.balancer = obj->balancerId();
         } break;
         }
+        msg.constraints[i].limiting = act.limiting() & (uint8_t(1) << i);
         msg.constraints_count++;
     }
+    msg.unconstrained = cnl::unwrap(act.unconstrained());
 }

--- a/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
@@ -86,8 +86,8 @@ getDigitalConstraints(blox_DigitalConstraints& msg, const ActuatorDigitalConstra
             msg.constraints[i].constraint.mutex = obj->mutexId();
         } break;
         }
+        msg.constraints[i].limiting = act.limiting() & (uint8_t(1) << i);
         msg.constraints_count++;
     }
-
-    msg.blocking = act.blockingConstraint();
+    msg.unconstrained = blox_AD_State(act.unconstrained());
 }

--- a/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
@@ -68,7 +68,7 @@ getDigitalConstraints(blox_DigitalConstraints& msg, const ActuatorDigitalConstra
     pb_size_t numConstraints = sizeof(msg.constraints) / sizeof(msg.constraints[0]);
     for (pb_size_t i = 0; i < numConstraints; ++i, ++it) {
         if (it == constraints.cend()) {
-            return;
+            break;
         }
         auto constraintId = (*it)->id();
         msg.constraints[i].which_constraint = constraintId;
@@ -88,4 +88,6 @@ getDigitalConstraints(blox_DigitalConstraints& msg, const ActuatorDigitalConstra
         }
         msg.constraints_count++;
     }
+
+    msg.blocking = act.blockingConstraint();
 }

--- a/app/brewblox/blox/BalancerBlock.h
+++ b/app/brewblox/blox/BalancerBlock.h
@@ -9,7 +9,7 @@
 
 class BalancerBlock : public Block<blox_Balancer_msgid> {
 public:
-    using Balancer_t = Balancer<blox_AnalogConstraint_balancer_tag>;
+    using Balancer_t = Balancer<blox_AnalogConstraint_balanced_tag>;
 
 private:
     Balancer_t balancer;

--- a/app/brewblox/blox/SetpointSensorPairBlock.h
+++ b/app/brewblox/blox/SetpointSensorPairBlock.h
@@ -45,6 +45,7 @@ public
         message.setpointValue = cnl::unwrap(pair.setting());
         message.sensorValid = sensor.valid();
         message.setpointValid = setpoint.valid();
+        message.valid = pair.valid();
 
         return streamProtoTo(out, &message, blox_SetpointSensorPair_fields, blox_SetpointSensorPair_size);
     }

--- a/app/brewblox/proto/AnalogConstraints.proto
+++ b/app/brewblox/proto/AnalogConstraints.proto
@@ -11,6 +11,10 @@ message AnalogConstraint {
     sint32 max = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
     uint32 balancer = 3 [ (brewblox).link = BalancerLink, (nanopb).int_size = IS_16 ];
   }
+  bool limiting = 100 [ (brewblox).readonly = true ];
 }
 
-message AnalogConstraints { repeated AnalogConstraint constraints = 1 [ (nanopb).max_count = 8 ]; }
+message AnalogConstraints { 
+  repeated AnalogConstraint constraints = 1 [ (nanopb).max_count = 8 ];
+  sint32 unconstrained = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+}

--- a/app/brewblox/proto/AnalogConstraints.proto
+++ b/app/brewblox/proto/AnalogConstraints.proto
@@ -6,10 +6,15 @@ import "nanopb.proto";
 package blox;
 
 message AnalogConstraint {
+  message Balanced {
+    uint32 balancerId = 1 [ (brewblox).link = BalancerLink, (nanopb).int_size = IS_16 ];
+    uint32 granted = 2 [ (brewblox).readonly = true ];
+  }
+
   oneof constraint {
     sint32 min = 1 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
     sint32 max = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
-    uint32 balancer = 3 [ (brewblox).link = BalancerLink, (nanopb).int_size = IS_16 ];
+    Balanced balanced = 3;
   }
   bool limiting = 100 [ (brewblox).readonly = true ];
 }

--- a/app/brewblox/proto/AnalogConstraints.proto
+++ b/app/brewblox/proto/AnalogConstraints.proto
@@ -8,7 +8,7 @@ package blox;
 message AnalogConstraint {
   message Balanced {
     uint32 balancerId = 1 [ (brewblox).link = BalancerLink, (nanopb).int_size = IS_16 ];
-    uint32 granted = 2 [ (brewblox).readonly = true ];
+    uint32 granted = 2 [ (brewblox).scale = 4096, (brewblox).readonly = true ];
   }
 
   oneof constraint {
@@ -19,7 +19,7 @@ message AnalogConstraint {
   bool limiting = 100 [ (brewblox).readonly = true ];
 }
 
-message AnalogConstraints { 
+message AnalogConstraints {
   repeated AnalogConstraint constraints = 1 [ (nanopb).max_count = 8 ];
   sint32 unconstrained = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
 }

--- a/app/brewblox/proto/DigitalConstraints.proto
+++ b/app/brewblox/proto/DigitalConstraints.proto
@@ -7,10 +7,13 @@ package blox;
 
 message DigitalConstraint {
   oneof constraint {
-    uint32 minOff = 1 [ (nanopb).int_size = IS_32 ];
-    uint32 minOn = 2 [ (nanopb).int_size = IS_32 ];
+    uint32 minOff = 1 [ (brewblox).unit = Time, (brewblox).scale = 1000, (nanopb).int_size = IS_32 ];
+    uint32 minOn = 2 [ (brewblox).unit = Time, (brewblox).scale = 1000, (nanopb).int_size = IS_32 ];
     uint32 mutex = 3 [ (brewblox).link = MutexLink, (nanopb).int_size = IS_16 ];
   }
 }
 
-message DigitalConstraints { repeated DigitalConstraint constraints = 1 [ (nanopb).max_count = 8 ]; }
+message DigitalConstraints {
+  repeated DigitalConstraint constraints = 1 [ (nanopb).max_count = 8 ];
+  uint32 blocking = 2;
+}

--- a/app/brewblox/proto/DigitalConstraints.proto
+++ b/app/brewblox/proto/DigitalConstraints.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "brewblox.proto";
 import "nanopb.proto";
+import "ActuatorDigital.proto";
 
 package blox;
 
@@ -11,9 +12,10 @@ message DigitalConstraint {
     uint32 minOn = 2 [ (brewblox).unit = Time, (brewblox).scale = 1000, (nanopb).int_size = IS_32 ];
     uint32 mutex = 3 [ (brewblox).link = MutexLink, (nanopb).int_size = IS_16 ];
   }
+  bool limiting = 100 [ (brewblox).readonly = true ];
 }
 
 message DigitalConstraints {
   repeated DigitalConstraint constraints = 1 [ (nanopb).max_count = 8 ];
-  uint32 blocking = 2;
+  AD.State unconstrained = 2 [ (brewblox).readonly = true ];
 }

--- a/app/brewblox/test/AcutatorOffsetBlock_test.cpp
+++ b/app/brewblox/test/AcutatorOffsetBlock_test.cpp
@@ -148,7 +148,8 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
         testBox.processInputToProto(decoded);
         CHECK(testBox.lastReplyHasStatusOk());
         CHECK(decoded.ShortDebugString() == "targetId: 102 targetValid: true referenceId: 105 referenceValid: true "
-                                            "setting: 49152 value: 4096"); // setting is 12 (setpoint difference), value is 1 (21 - 20)
+                                            "setting: 49152 value: 4096 " // setting is 12 (setpoint difference), value is 1 (21 - 20)
+                                            "constrainedBy { unconstrained: 49152 }");
     }
 
     // read reference pair

--- a/app/brewblox/test/AcutatorPinBlock_test.cpp
+++ b/app/brewblox/test/AcutatorPinBlock_test.cpp
@@ -89,9 +89,9 @@ SCENARIO("An ActuatorPinBlock")
         writeState(blox::AD_State_Active);
         CHECK(decoded.ShortDebugString() == "invert: true "
                                             "constrainedBy { "
-                                            "constraints { minOff: 180000 } "
+                                            "constraints { minOff: 180000 limiting: true } "
                                             "constraints { minOn: 120000 } "
-                                            "blocking: 1 }");
+                                            "unconstrained: Active }");
 
         testBox.update(200000);
 
@@ -101,7 +101,8 @@ SCENARIO("An ActuatorPinBlock")
                                             "invert: true "
                                             "constrainedBy { "
                                             "constraints { minOff: 180000 } "
-                                            "constraints { minOn: 120000 } }");
+                                            "constraints { minOn: 120000 } "
+                                            "unconstrained: Active }");
         testBox.update(201000);
 
         // will refuse to turn OFF
@@ -110,8 +111,8 @@ SCENARIO("An ActuatorPinBlock")
                                             "invert: true "
                                             "constrainedBy { "
                                             "constraints { minOff: 180000 } "
-                                            "constraints { minOn: 120000 } "
-                                            "blocking: 2 }");
+                                            "constraints { minOn: 120000 limiting: true } "
+                                            "}");
 
         testBox.update(500000);
 
@@ -120,6 +121,7 @@ SCENARIO("An ActuatorPinBlock")
         CHECK(decoded.ShortDebugString() == "invert: true "
                                             "constrainedBy { "
                                             "constraints { minOff: 180000 } "
-                                            "constraints { minOn: 120000 } }");
+                                            "constraints { minOn: 120000 } "
+                                            "}");
     }
 }

--- a/app/brewblox/test/AcutatorPwmBlock_test.cpp
+++ b/app/brewblox/test/AcutatorPwmBlock_test.cpp
@@ -61,5 +61,6 @@ SCENARIO("A Blox ActuatorPwm object can be created from streamed protobuf data")
     CHECK(testBox.lastReplyHasStatusOk());
     CHECK(decoded.ShortDebugString() == "actuatorId: 10 actuatorValid: true "
                                         "period: 4000 setting: 81920 "
-                                        "constrainedBy { constraints { min: 40960 } }");
+                                        "constrainedBy { constraints { min: 40960 } "
+                                        "unconstrained: 81920 }");
 }

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -91,7 +91,9 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         newPwm.set_period(4000);
 
         auto c = newPwm.mutable_constrainedby()->add_constraints();
-        c->set_balancer(100);
+        auto balanced = new blox::AnalogConstraint_Balanced();
+        balanced->set_balancerid(100);
+        c->set_allocated_balanced(balanced);
 
         testBox.put(newPwm);
     }
@@ -129,7 +131,9 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         newPwm.set_period(4000);
 
         auto c = newPwm.mutable_constrainedby()->add_constraints();
-        c->set_balancer(100);
+        auto balanced = new blox::AnalogConstraint_Balanced();
+        balanced->set_balancerid(100);
+        c->set_allocated_balanced(balanced);
 
         testBox.put(newPwm);
     }
@@ -195,7 +199,10 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         CHECK(testBox.lastReplyHasStatusOk());
         CHECK(decoded.ShortDebugString() == "actuatorId: 10 actuatorValid: true "
                                             "period: 4000 setting: 204800 "
-                                            "constrainedBy { constraints { balancer: 100 limiting: true } "
+                                            "constrainedBy { "
+                                            "constraints { "
+                                            "balanced { balancerId: 100 granted: 204800 } "
+                                            "limiting: true } "
                                             "unconstrained: 327680 }");
     }
 
@@ -209,7 +216,10 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         CHECK(testBox.lastReplyHasStatusOk());
         CHECK(decoded.ShortDebugString() == "actuatorId: 11 actuatorValid: true "
                                             "period: 4000 setting: 204800 "
-                                            "constrainedBy { constraints { balancer: 100 limiting: true } "
+                                            "constrainedBy { "
+                                            "constraints { "
+                                            "balanced { balancerId: 100 granted: 204800 } "
+                                            "limiting: true } "
                                             "unconstrained: 327680 }");
     }
 

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -163,7 +163,7 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         CHECK(decoded.ShortDebugString() == "differentActuatorWait: 100");
     }
 
-    // read a pin actuator
+    // read a pin actuator 1
     testBox.put(commands::READ_OBJECT);
     testBox.put(cbox::obj_id_t(10));
 
@@ -171,10 +171,21 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         auto decoded = blox::ActuatorPin();
         testBox.processInputToProto(decoded);
         CHECK(testBox.lastReplyHasStatusOk());
-        CHECK(decoded.ShortDebugString() == "state: Active constrainedBy { constraints { mutex: 101 } }");
+        CHECK(decoded.ShortDebugString() == "constrainedBy { constraints { mutex: 101 limiting: true } unconstrained: Active }");
     }
 
-    // read a pwm actuator
+    // read a pin actuator 2
+    testBox.put(commands::READ_OBJECT);
+    testBox.put(cbox::obj_id_t(11));
+
+    {
+        auto decoded = blox::ActuatorPin();
+        testBox.processInputToProto(decoded);
+        CHECK(testBox.lastReplyHasStatusOk());
+        CHECK(decoded.ShortDebugString() == "state: Active constrainedBy { constraints { mutex: 101 } unconstrained: Active }");
+    }
+
+    // read a pwm actuator 1
     testBox.put(commands::READ_OBJECT);
     testBox.put(cbox::obj_id_t(201));
 
@@ -184,7 +195,22 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
         CHECK(testBox.lastReplyHasStatusOk());
         CHECK(decoded.ShortDebugString() == "actuatorId: 10 actuatorValid: true "
                                             "period: 4000 setting: 204800 "
-                                            "constrainedBy { constraints { balancer: 100 } }");
+                                            "constrainedBy { constraints { balancer: 100 limiting: true } "
+                                            "unconstrained: 327680 }");
+    }
+
+    // read a pwm actuator 2
+    testBox.put(commands::READ_OBJECT);
+    testBox.put(cbox::obj_id_t(301));
+
+    {
+        auto decoded = blox::ActuatorPwm();
+        testBox.processInputToProto(decoded);
+        CHECK(testBox.lastReplyHasStatusOk());
+        CHECK(decoded.ShortDebugString() == "actuatorId: 11 actuatorValid: true "
+                                            "period: 4000 setting: 204800 "
+                                            "constrainedBy { constraints { balancer: 100 limiting: true } "
+                                            "unconstrained: 327680 }");
     }
 
     // run for a while

--- a/app/brewblox/test/SetpointSensorPairBlock_test.cpp
+++ b/app/brewblox/test/SetpointSensorPairBlock_test.cpp
@@ -66,6 +66,7 @@ SCENARIO("A Blox SetpointSensorPair object can be created from streamed protobuf
 
     blox::SetpointSimple newSetpoint;
     newSetpoint.set_setting(cnl::unwrap(temp_t(21.0)));
+    newSetpoint.set_valid(true);
     testBox.put(newSetpoint);
 
     testBox.processInput();

--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -153,12 +153,13 @@ public:
         : m_mutex(mut)
     {
     }
+    ~Mutex() = default;
 
     virtual bool allowed(const State& newState, const ticks_millis_t& now, const ActuatorDigitalChangeLogged& act) override final
     {
         if (newState == State::Inactive) {
             // always allow switching OFF, but release mutex
-            if (hasLock) {
+            if (act.state() == State::Active) {
                 if (auto mutPtr = m_mutex()) {
                     mutPtr->unlock(now, act);
                     hasLock = false;

--- a/lib/inc/ActuatorPin.h
+++ b/lib/inc/ActuatorPin.h
@@ -65,6 +65,8 @@ public:
 
     void invert(bool inv)
     {
+        auto active = state();
         m_invert = inv;
+        state(active);
     }
 };

--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -78,6 +78,19 @@ public:
         return val;
     }
 
+    value_t granted(const Balanced* req) const
+    {
+        auto match = find_if(requesters.begin(), requesters.end(), [&req](const Request& r) {
+            return r.requester == req;
+        });
+
+        if (match == requesters.end()) {
+            return 0;
+        }
+
+        return match->granted;
+    }
+
     void update()
     {
         auto numActuators = requesters.size();
@@ -148,6 +161,14 @@ public:
     virtual uint8_t id() const
     {
         return ID;
+    }
+
+    value_t granted() const
+    {
+        if (auto balancerPtr = m_balancer()) {
+            return balancerPtr->granted(this);
+        }
+        return 0;
     }
 };
 }

--- a/lib/inc/Setpoint.h
+++ b/lib/inc/Setpoint.h
@@ -56,6 +56,7 @@ public:
     virtual void setting(const temp_t& val) override final
     {
         m_setting = val;
+        m_valid = true;
     }
 
     virtual bool valid() const override final


### PR DESCRIPTION
This PR adds some additional info to constraints on analog and digital actuators.
Each constraint has an extra field whether it limited the actuator value and the unconstrained value is made available.

Some issues in mutex handling while rewriting constraints came up and were fixed.
When the invert setting of a digital pin actuator was toggled, this could bypass the mutex, because the active/not active state would flip without being set externally. Fixed by toggling the hardware pin when invert is changed.

Now that constrained actuators remember their unconstrained value, this unconstrained value is used to re-apply constraints during update. This also means that toggles can remain 'pending' until time constraints are resolved.
