### PR TITLE
Sort constraints so balancer and mutex are last

### DIFF
--- a/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorAnalogConstraintsProto.cpp
@@ -44,6 +44,11 @@ public:
     {
         return m_balanced.granted();
     }
+
+    virtual uint8_t order() const override final
+    {
+        return m_balanced.order();
+    }
 };
 
 void

--- a/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
+++ b/app/brewblox/blox/ActuatorDigitalConstraintsProto.cpp
@@ -36,6 +36,11 @@ public:
     {
         return m_mutexConstraint.allowed(newState, now, act);
     };
+
+    virtual uint8_t order() const override final
+    {
+        return m_mutexConstraint.order();
+    }
 };
 
 void

--- a/app/brewblox/blox/ActuatorOffsetBlock.h
+++ b/app/brewblox/blox/ActuatorOffsetBlock.h
@@ -53,6 +53,7 @@ public:
 
         message.setting = cnl::unwrap(constrained.setting());
         message.value = cnl::unwrap(constrained.value());
+        message.valid = constrained.valid();
         getAnalogConstraints(message.constrainedBy, constrained);
 
         return streamProtoTo(out, &message, blox_ActuatorOffset_fields, blox_ActuatorOffset_size);

--- a/app/brewblox/blox/ActuatorPwmBlock.h
+++ b/app/brewblox/blox/ActuatorPwmBlock.h
@@ -52,6 +52,7 @@ public:
         message.period = pwm.period();
         message.setting = cnl::unwrap(constrained.setting());
         message.value = cnl::unwrap(constrained.value());
+        message.valid = constrained.valid();
         getAnalogConstraints(message.constrainedBy, constrained);
 
         return streamProtoTo(out, &message, blox_ActuatorPwm_fields, blox_ActuatorPwm_size);

--- a/app/brewblox/proto/ActuatorAnalogMock.proto
+++ b/app/brewblox/proto/ActuatorAnalogMock.proto
@@ -6,12 +6,12 @@ import "nanopb.proto";
 package blox;
 
 message ActuatorAnalogMock {
-    option (nanopb_msgopt).msgid = 305;
-    sint32 setting = 1 [(brewblox).scale = 4096, (nanopb).int_size = IS_32];
-    sint32 value = 2 [(brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true];
-    bool valid = 3 [(brewblox).readonly = true];
-    sint32 minSetting = 4 [(brewblox).scale = 4096, (nanopb).int_size = IS_32];
-    sint32 maxSetting = 5 [(brewblox).scale = 4096, (nanopb).int_size = IS_32];
-    sint32 minValue = 6 [(brewblox).scale = 4096, (nanopb).int_size = IS_32];
-    sint32 maxValue = 7 [(brewblox).scale = 4096, (nanopb).int_size = IS_32];
+  option (nanopb_msgopt).msgid = 305;
+  sint32 setting = 1 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
+  sint32 value = 2 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
+  bool valid = 3 [ (brewblox).readonly = true ];
+  sint32 minSetting = 4 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
+  sint32 maxSetting = 5 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
+  sint32 minValue = 6 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
+  sint32 maxValue = 7 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
 }

--- a/app/brewblox/proto/ActuatorOffset.proto
+++ b/app/brewblox/proto/ActuatorOffset.proto
@@ -22,4 +22,5 @@ message ActuatorOffset {
   sint32 setting = 6 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   sint32 value = 7 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   AnalogConstraints constrainedBy = 8;
+  bool valid = 9 [ (brewblox).readonly = true ];
 }

--- a/app/brewblox/proto/ActuatorPwm.proto
+++ b/app/brewblox/proto/ActuatorPwm.proto
@@ -15,4 +15,5 @@ message ActuatorPwm {
   sint32 setting = 4 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32 ];
   sint32 value = 5 [ (brewblox).scale = 4096, (nanopb).int_size = IS_32, (brewblox).readonly = true ];
   AnalogConstraints constrainedBy = 6;
+  bool valid = 7 [ (brewblox).readonly = true ];
 }

--- a/app/brewblox/test/AcutatorOffsetBlock_test.cpp
+++ b/app/brewblox/test/AcutatorOffsetBlock_test.cpp
@@ -149,7 +149,8 @@ SCENARIO("A Blox ActuatorOffset object can be created from streamed protobuf dat
         CHECK(testBox.lastReplyHasStatusOk());
         CHECK(decoded.ShortDebugString() == "targetId: 102 targetValid: true referenceId: 105 referenceValid: true "
                                             "setting: 49152 value: 4096 " // setting is 12 (setpoint difference), value is 1 (21 - 20)
-                                            "constrainedBy { unconstrained: 49152 }");
+                                            "constrainedBy { unconstrained: 49152 } "
+                                            "valid: true");
     }
 
     // read reference pair

--- a/app/brewblox/test/AcutatorPwmBlock_test.cpp
+++ b/app/brewblox/test/AcutatorPwmBlock_test.cpp
@@ -62,5 +62,5 @@ SCENARIO("A Blox ActuatorPwm object can be created from streamed protobuf data")
     CHECK(decoded.ShortDebugString() == "actuatorId: 10 actuatorValid: true "
                                         "period: 4000 setting: 81920 "
                                         "constrainedBy { constraints { min: 40960 } "
-                                        "unconstrained: 81920 }");
+                                        "unconstrained: 81920 } valid: true");
 }

--- a/app/brewblox/test/BalancerAndMutexBlock_test.cpp
+++ b/app/brewblox/test/BalancerAndMutexBlock_test.cpp
@@ -203,7 +203,8 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
                                             "constraints { "
                                             "balanced { balancerId: 100 granted: 204800 } "
                                             "limiting: true } "
-                                            "unconstrained: 327680 }");
+                                            "unconstrained: 327680 } "
+                                            "valid: true");
     }
 
     // read a pwm actuator 2
@@ -220,7 +221,8 @@ SCENARIO("Two PWM actuators can be constrained by a balancer")
                                             "constraints { "
                                             "balanced { balancerId: 100 granted: 204800 } "
                                             "limiting: true } "
-                                            "unconstrained: 327680 }");
+                                            "unconstrained: 327680 } "
+                                            "valid: true");
     }
 
     // run for a while

--- a/lib/inc/ActuatorAnalogConstrained.h
+++ b/lib/inc/ActuatorAnalogConstrained.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "ActuatorAnalog.h"
+#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/lib/inc/ActuatorAnalogConstrained.h
+++ b/lib/inc/ActuatorAnalogConstrained.h
@@ -40,6 +40,8 @@ public:
     virtual value_t constrain(const value_t& val) const = 0;
 
     virtual uint8_t id() const = 0;
+
+    virtual uint8_t order() const = 0;
 };
 
 template <uint8_t ID>
@@ -66,6 +68,11 @@ public:
     value_t min() const
     {
         return m_min;
+    }
+
+    virtual uint8_t order() const override final
+    {
+        return 0;
     }
 };
 
@@ -94,12 +101,18 @@ public:
     {
         return m_max;
     }
+
+    virtual uint8_t order() const override final
+    {
+        return 1;
+    }
 };
 }
 
 /*
  * An ActuatorAnalog has a range output
  */
+
 class ActuatorAnalogConstrained : public ActuatorAnalog {
 public:
     using Constraint = AAConstraints::Base;
@@ -126,6 +139,9 @@ public:
         if (constraints.size() < 8) {
             constraints.push_back(std::move(newConstraint));
         }
+
+        std::sort(constraints.begin(), constraints.end(),
+                  [](const std::unique_ptr<Constraint>& a, const std::unique_ptr<Constraint>& b) { return a->order() < b->order(); });
     }
 
     void removeAllConstraints()
@@ -152,6 +168,7 @@ public:
             }
             bit = bit << 1;
         }
+
         actuator.setting(result);
     }
 

--- a/lib/inc/ActuatorAnalogConstrained.h
+++ b/lib/inc/ActuatorAnalogConstrained.h
@@ -175,6 +175,11 @@ public:
         return actuator.valid();
     }
 
+    virtual void valid(bool v) override final
+    {
+        actuator.valid(v);
+    }
+
     value_t unconstrained() const
     {
         return m_unconstrained;

--- a/lib/inc/ActuatorAnalogMock.h
+++ b/lib/inc/ActuatorAnalogMock.h
@@ -37,6 +37,7 @@ private:
     value_t m_maxValue = cnl::numeric_limits<value_t>::max();
 
     value_t m_setting = 0;
+    bool m_valid = true;
 
 public:
     // construct without arguments, val = invalid, min and max are defaults
@@ -112,8 +113,13 @@ public:
         m_maxValue = arg;
     }
 
-    bool valid() const
+    bool valid() const override final
     {
-        return true;
+        return m_valid;
+    }
+
+    void valid(bool v) override final
+    {
+        m_valid = v;
     }
 };

--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -22,6 +22,7 @@
 #include "ActuatorDigital.h"
 #include "ActuatorDigitalChangeLogged.h"
 #include "TicksTypes.h"
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -159,7 +159,7 @@ public:
     {
         if (newState == State::Inactive) {
             // always allow switching OFF, but release mutex
-            if (act.state() == State::Active) {
+            if (act.state() == State::Active || hasLock) {
                 if (auto mutPtr = m_mutex()) {
                     mutPtr->unlock(now, act);
                     hasLock = false;

--- a/lib/inc/ActuatorDigitalConstrained.h
+++ b/lib/inc/ActuatorDigitalConstrained.h
@@ -77,6 +77,8 @@ public:
     virtual bool allowed(const State& newState, const ticks_millis_t& now, const ActuatorDigitalChangeLogged& act) = 0;
 
     virtual uint8_t id() const = 0;
+
+    virtual uint8_t order() const = 0;
 };
 
 template <uint8_t ID>
@@ -108,6 +110,11 @@ public:
     {
         return m_limit;
     }
+
+    virtual uint8_t order() const override final
+    {
+        return 1;
+    }
 };
 
 template <uint8_t ID>
@@ -138,6 +145,11 @@ public:
     duration_millis_t limit()
     {
         return m_limit;
+    }
+
+    virtual uint8_t order() const override final
+    {
+        return 0;
     }
 };
 
@@ -188,6 +200,11 @@ public:
     {
         return ID;
     }
+
+    virtual uint8_t order() const override final
+    {
+        return 2;
+    }
 };
 
 } // end namespace ADConstraints
@@ -217,6 +234,8 @@ public:
         if (constraints.size() < 8) {
             constraints.push_back(std::move(newConstraint));
         }
+        std::sort(constraints.begin(), constraints.end(),
+                  [](const std::unique_ptr<Constraint>& a, const std::unique_ptr<Constraint>& b) { return a->order() < b->order(); });
     }
 
     void removeAllConstraints()
@@ -235,8 +254,8 @@ public:
         uint8_t bit = 0x01;
         for (auto& c : constraints) {
             if (!c->allowed(val, now, *this)) {
-                // don't exit early, all constraints need to be updated
                 limiting = limiting | bit;
+                break;
             }
             bit = bit << 1;
         }
@@ -252,10 +271,7 @@ public:
     {
         m_unconstrained = val;
         m_limiting = checkConstraints(val, now);
-        if (m_limiting != 0) {
-            // Check constraints again with current state to reset any state keeping contstraints like mutex
-            checkConstraints(ActuatorDigitalChangeLogged::state(), now);
-        } else {
+        if (m_limiting == 0) {
             ActuatorDigitalChangeLogged::state(val, now);
         }
     }

--- a/lib/inc/ActuatorOffset.h
+++ b/lib/inc/ActuatorOffset.h
@@ -80,6 +80,13 @@ public:
         return false;
     }
 
+    virtual void valid(bool v) override final
+    {
+        if (auto targetPtr = m_target()) {
+            return targetPtr->valid(v);
+        }
+    }
+
     void selectedReference(const SettingOrValue& sel)
     {
         m_selectedReference = sel;
@@ -97,12 +104,15 @@ public:
 
         if (auto targetPtr = m_target()) {
             if (auto refPtr = m_reference()) {
-                if (targetPtr->valid() && refPtr->valid()) {
-                    referenceValue = (m_selectedReference == SettingOrValue::SETTING) ? refPtr->setting() : refPtr->value();
-                    targetPtr->setting(referenceValue + m_setting);
-                    targetValue = targetPtr->value();
-                    m_value = targetValue - referenceValue;
-                    return;
+                if (refPtr->valid()) {
+                    targetPtr->valid(true); // try to make target valid
+                    if (targetPtr->valid()) {
+                        referenceValue = (m_selectedReference == SettingOrValue::SETTING) ? refPtr->setting() : refPtr->value();
+                        targetPtr->setting(referenceValue + m_setting);
+                        targetValue = targetPtr->value();
+                        m_value = targetValue - referenceValue;
+                        return;
+                    }
                 }
             }
             targetPtr->valid(false);

--- a/lib/inc/ActuatorPwm.h
+++ b/lib/inc/ActuatorPwm.h
@@ -105,4 +105,6 @@ public:
     }
 
     virtual bool valid() const override final;
+
+    virtual void valid(bool v) override final;
 };

--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -170,5 +170,9 @@ public:
         }
         return 0;
     }
+    virtual uint8_t order() const override final
+    {
+        return 2;
+    }
 };
 }

--- a/lib/inc/Pid.h
+++ b/lib/inc/Pid.h
@@ -195,14 +195,8 @@ public:
 private:
     void active(bool state)
     {
-        if (!state) {
-            m_error = 0;
-            m_p = 0;
-            m_i = 0;
-            m_d = 0;
-            if (auto ptr = m_outputPtr()) {
-                ptr->setting(in_t(0));
-            }
+        if (auto ptr = m_outputPtr()) {
+            ptr->valid(state);
         }
         m_active = state;
     }

--- a/lib/inc/ProcessValue.h
+++ b/lib/inc/ProcessValue.h
@@ -39,4 +39,6 @@ public:
     virtual T value() const = 0;
     // returns whether the process value is valid (data can be trusted)
     virtual bool valid() const = 0;
+    // writes valid flag (will set setting to invalid)
+    virtual void valid(bool v) = 0;
 };

--- a/lib/inc/SetpointSensorPair.h
+++ b/lib/inc/SetpointSensorPair.h
@@ -80,9 +80,8 @@ public:
         return false;
     }
 
-    void valid(bool v)
+    virtual void valid(bool v) override final
     {
-
         if (auto sp = setpoint()) {
             sp->valid(v);
         }

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -144,3 +144,14 @@ ActuatorPwm::valid() const
     }
     return false;
 }
+
+void
+ActuatorPwm::valid(bool v)
+{
+    if (!v) {
+        if (auto actPtr = m_target()) {
+            actPtr->state(State::Inactive);
+        }
+        setting(0);
+    }
+}

--- a/lib/test_catch/ActuatorPwm_test.cpp
+++ b/lib/test_catch/ActuatorPwm_test.cpp
@@ -38,7 +38,8 @@
 using value_t = ActuatorAnalog::value_t;
 using State = ActuatorDigital::State;
 
-auto output = &std::cout;
+// auto output = &std::cout; // uncomment for stdout output
+auto output = std::make_unique<std::ofstream>(); // use unopened file stream for no output
 
 double
 randomIntervalTest(const int& numPeriods,


### PR DESCRIPTION
To request only the maximum value under other constraints from the balancer, it should be the last constraint in the list.
Same goes for the mutex to not lock/unlock it unnecessarily. This change also allows early exit when checking digital constraints.