### PR TITLE
re-evaluate constraints after setting actuator to invalid

### DIFF
--- a/lib/inc/ActuatorAnalogConstrained.h
+++ b/lib/inc/ActuatorAnalogConstrained.h
@@ -196,6 +196,8 @@ public:
     virtual void valid(bool v) override final
     {
         actuator.valid(v);
+        // re-apply setting for when actuator has constrained it due to being invalid
+        setting(actuator.setting());
     }
 
     value_t unconstrained() const

--- a/lib/inc/ActuatorOffset.h
+++ b/lib/inc/ActuatorOffset.h
@@ -83,7 +83,7 @@ public:
     virtual void valid(bool v) override final
     {
         if (auto targetPtr = m_target()) {
-            return targetPtr->valid(v);
+            targetPtr->valid(v);
         }
     }
 

--- a/lib/inc/ActuatorPwm.h
+++ b/lib/inc/ActuatorPwm.h
@@ -41,6 +41,7 @@ private:
     duration_millis_t m_dutyTime = 0;
     value_t m_dutySetting = 0;
     value_t m_dutyAchieved = 0;
+    bool m_valid = true;
 
 public:
     /** Constructor.

--- a/lib/inc/Balancer.h
+++ b/lib/inc/Balancer.h
@@ -52,7 +52,7 @@ public:
 
     void registerEntry(const Balanced* req)
     {
-        requesters.push_back(Request{req, 0, available});
+        requesters.push_back(Request{req, available, 0});
     }
 
     void unregisterEntry(const Balanced* req)
@@ -66,16 +66,12 @@ public:
             return r.requester == req;
         });
 
-        if (match == requesters.end()) {
-            registerEntry(req);
-            match = (requesters.end() - 1);
-        }
-
         if (match != requesters.end()) {
             match->requested = val;
             return std::min(val, match->granted);
         };
-        return val;
+
+        return 0; // not found. Should not be possible because Balanced registers in constructor
     }
 
     value_t granted(const Balanced* req) const
@@ -136,6 +132,9 @@ public:
         std::function<std::shared_ptr<Balancer<ID>>()>&& balancer)
         : m_balancer(balancer)
     {
+        if (auto balancerPtr = m_balancer()) {
+            balancerPtr->registerEntry(this);
+        }
     }
 
     Balanced(const Balanced&) = delete;

--- a/lib/src/ActuatorPwm.cpp
+++ b/lib/src/ActuatorPwm.cpp
@@ -13,8 +13,10 @@ ActuatorPwm::ActuatorPwm(
 void
 ActuatorPwm::setting(value_t const& val)
 {
-    m_dutySetting = std::clamp(val, value_t(0), value_t(100));
-    m_dutyTime = duration_millis_t((m_dutySetting * m_period) / value_t(100));
+    if (valid()) {
+        m_dutySetting = std::clamp(val, value_t(0), value_t(100));
+        m_dutyTime = duration_millis_t((m_dutySetting * m_period) / value_t(100));
+    }
 }
 
 // returns the actual achieved PWM value, not the set value
@@ -140,7 +142,7 @@ bool
 ActuatorPwm::valid() const
 {
     if (auto actPtr = m_target()) {
-        return actPtr->state() != State::Unknown;
+        return m_valid && actPtr->state() != State::Unknown;
     }
     return false;
 }
@@ -154,4 +156,5 @@ ActuatorPwm::valid(bool v)
         }
         setting(0);
     }
+    m_valid = v;
 }

--- a/lib/test_catch/ActuatorAnalogConstrained_test.cpp
+++ b/lib/test_catch/ActuatorAnalogConstrained_test.cpp
@@ -96,8 +96,11 @@ SCENARIO("When two analog actuators are constrained by a balancer", "[constraint
     cAct1.setting(60);
     cAct2.setting(60);
 
-    CHECK(cAct1.setting() == value_t(60));
-    CHECK(cAct2.setting() == value_t(60));
+    THEN("The actuator setting is zero until the first update of the balancer")
+    {
+        CHECK(cAct1.setting() == value_t(0));
+        CHECK(cAct2.setting() == value_t(0));
+    }
 
     THEN("After the balancer has updated, the values are constrained to not exceed the maximum available for the balancer, weighted by previous request")
     {

--- a/lib/test_catch/ActuatorPwm_test.cpp
+++ b/lib/test_catch/ActuatorPwm_test.cpp
@@ -316,6 +316,19 @@ SCENARIO("ActuatorPWM driving mock actuator", "[pwm]")
         CHECK(randomIntervalTest(10, pwm, mock, 4.0, 500, now) == Approx(4.0).margin(0.5));
         CHECK(randomIntervalTest(10, pwm, mock, 96.0, 500, now) == Approx(96.0).margin(0.5));
     }
+
+    WHEN("PWM actuator is set to invalid, the output pin is low")
+    {
+        // values typical for a fridge compressor
+        pwm.setting(100);
+        pwm.update(now);
+
+        CHECK(mock.state() == State::Active);
+
+        pwm.valid(false);
+
+        CHECK(mock.state() == State::Inactive);
+    }
 }
 
 SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
@@ -418,6 +431,19 @@ SCENARIO("Two PWM actuators driving mutually exclusive digital actuators")
             checkDuties(90, 20, 90.0 / 1.1, 20.0 / 1.1);
             checkDuties(95, 10, 95.0 / 1.05, 10.0 / 1.05);
             checkDuties(85, 25, 85.0 / 1.1, 25.0 / 1.1);
+        }
+
+        AND_WHEN("A PWM is set to invalid, its requested value is zero in the balancer")
+        {
+            constrainedPwm1.setting(50);
+            constrainedPwm1.valid(false);
+
+            constrainedPwm1.update();
+            constrainedPwm2.update();
+
+            balancer->update();
+
+            CHECK(balancer->clients()[0].requested == 0);
         }
     }
 }


### PR DESCRIPTION
Scenario as reported by @glibersat 
- PID is driving balanced PWM actuator
- PID gets invalid input (setpoint disabled or sensor lost)
- PID sets actuator to invalid.

Reported:
- PWM value can still be non-zero
- Requested value at the balancer is still non-zero

Fixes:
- After setting flag on a constrained actuator, re-evaluate constraints so the requested value is updated
- PWM actuator needed extra valid flag instead of just setting its setting to zero
- Rewriting code triggered a segfault in unit tests. Fixed by registering balanced actuators on construction instead of first request
